### PR TITLE
Remove package variables for tracking handlers

### DIFF
--- a/filter_policy.go
+++ b/filter_policy.go
@@ -3,9 +3,9 @@ package gorocksdb
 // #include "rocksdb/c.h"
 // #include "gorocksdb.h"
 import "C"
-
-var filterHandlers = make(map[int]FilterPolicyHandler)
-var filterNextId int
+import (
+	"unsafe"
+)
 
 // FilterPolicy is a factory type that allows the RocksDB database to create a
 // filter, such as a bloom filter, which will used to reduce reads.
@@ -31,11 +31,8 @@ type FilterPolicyHandler interface {
 
 // NewFilterPolicy creates a new filter policy for the given handler.
 func NewFilterPolicy(handler FilterPolicyHandler) *FilterPolicy {
-	filterNextId++
-	id := filterNextId
-	filterHandlers[id] = handler
-
-	return NewNativeFilterPolicy(C.gorocksdb_filterpolicy_create(C.size_t(id)))
+	h := unsafe.Pointer(&handler)
+	return NewNativeFilterPolicy(C.gorocksdb_filterpolicy_create(h))
 }
 
 // Return a new filter policy that uses a bloom filter with approximately
@@ -65,7 +62,7 @@ func (self *FilterPolicy) Destroy() {
 }
 
 //export gorocksdb_filterpolicy_create_filter
-func gorocksdb_filterpolicy_create_filter(id int, cKeys **C.char, cKeysLen *C.size_t, cNumKeys C.int, cDstLen *C.size_t) *C.char {
+func gorocksdb_filterpolicy_create_filter(handler *FilterPolicyHandler, cKeys **C.char, cKeysLen *C.size_t, cNumKeys C.int, cDstLen *C.size_t) *C.char {
 	keys := make([][]byte, int(cNumKeys))
 	for i, l := 0, int(cNumKeys); i < l; i++ {
 		cKey := C.gorocksdb_get_char_at_index(cKeys, C.int(i))
@@ -74,8 +71,7 @@ func gorocksdb_filterpolicy_create_filter(id int, cKeys **C.char, cKeysLen *C.si
 		keys[i] = CharToByte(cKey, cKeyLen)
 	}
 
-	handler := filterHandlers[id]
-	dst := handler.CreateFilter(keys)
+	dst := (*handler).CreateFilter(keys)
 
 	*cDstLen = C.size_t(len(dst))
 
@@ -83,19 +79,16 @@ func gorocksdb_filterpolicy_create_filter(id int, cKeys **C.char, cKeysLen *C.si
 }
 
 //export gorocksdb_filterpolicy_key_may_match
-func gorocksdb_filterpolicy_key_may_match(id int, cKey *C.char, cKeyLen C.size_t, cFilter *C.char, cFilterLen C.size_t) C.uchar {
+func gorocksdb_filterpolicy_key_may_match(handler *FilterPolicyHandler, cKey *C.char, cKeyLen C.size_t, cFilter *C.char, cFilterLen C.size_t) C.uchar {
 	key := CharToByte(cKey, cKeyLen)
 	filter := CharToByte(cFilter, cFilterLen)
 
-	handler := filterHandlers[id]
-	match := handler.KeyMayMatch(key, filter)
+	match := (*handler).KeyMayMatch(key, filter)
 
 	return BoolToChar(match)
 }
 
 //export gorocksdb_filterpolicy_name
-func gorocksdb_filterpolicy_name(id int) *C.char {
-	handler := filterHandlers[id]
-
-	return StringToChar(handler.Name())
+func gorocksdb_filterpolicy_name(handler *FilterPolicyHandler) *C.char {
+	return StringToChar((*handler).Name())
 }

--- a/gorocksdb.c
+++ b/gorocksdb.c
@@ -3,13 +3,13 @@
 
 /* Base */
 
-void gorocksdb_destruct_handler(void* id) { }
+void gorocksdb_destruct_handler(void* state) { }
 
 /* Comparator */
 
-rocksdb_comparator_t* gorocksdb_comparator_create(size_t id) {
+rocksdb_comparator_t* gorocksdb_comparator_create(void* state) {
     return rocksdb_comparator_create(
-        (void*)id,
+        state,
         gorocksdb_destruct_handler,
         (int (*)(void*, const char*, size_t, const char*, size_t))(gorocksdb_comparator_compare),
         (const char *(*)(void*))(gorocksdb_comparator_name));
@@ -17,9 +17,9 @@ rocksdb_comparator_t* gorocksdb_comparator_create(size_t id) {
 
 /* Filter Policy */
 
-rocksdb_filterpolicy_t* gorocksdb_filterpolicy_create(size_t id) {
+rocksdb_filterpolicy_t* gorocksdb_filterpolicy_create(void* state) {
     return rocksdb_filterpolicy_create(
-        (void*)id,
+        state,
         gorocksdb_destruct_handler,
         (char* (*)(void*, const char* const*, const size_t*, int, size_t*))(gorocksdb_filterpolicy_create_filter),
         (unsigned char (*)(void*, const char*, size_t, const char*, size_t))(gorocksdb_filterpolicy_key_may_match),
@@ -27,13 +27,13 @@ rocksdb_filterpolicy_t* gorocksdb_filterpolicy_create(size_t id) {
         (const char *(*)(void*))(gorocksdb_filterpolicy_name));
 }
 
-void gorocksdb_filterpolicy_delete_filter(void* id, const char* v, size_t s) { }
+void gorocksdb_filterpolicy_delete_filter(void* state, const char* v, size_t s) { }
 
 /* Merge Operator */
 
-rocksdb_mergeoperator_t* gorocksdb_mergeoperator_create(size_t id) {
+rocksdb_mergeoperator_t* gorocksdb_mergeoperator_create(void* state) {
     return rocksdb_mergeoperator_create(
-        (void*)id,
+        state,
         gorocksdb_destruct_handler,
         (char* (*)(void*, const char*, size_t, const char*, size_t, const char* const*, const size_t*, int, unsigned char*, size_t*))(gorocksdb_mergeoperator_full_merge),
         (char* (*)(void*, const char*, size_t, const char* const*, const size_t*, int, unsigned char*, size_t*))(gorocksdb_mergeoperator_partial_merge_multi),
@@ -45,9 +45,9 @@ void gorocksdb_mergeoperator_delete_value(void* id, const char* v, size_t s) { }
 
 /* Slice Transform */
 
-rocksdb_slicetransform_t* gorocksdb_slicetransform_create(size_t id) {
+rocksdb_slicetransform_t* gorocksdb_slicetransform_create(void* state) {
     return rocksdb_slicetransform_create(
-    	(void*)id,
+    	state,
     	gorocksdb_destruct_handler,
     	(char* (*)(void*, const char*, size_t, size_t*))(gorocksdb_slicetransform_transform),
     	(unsigned char (*)(void*, const char*, size_t))(gorocksdb_slicetransform_in_domain),

--- a/gorocksdb.h
+++ b/gorocksdb.h
@@ -9,21 +9,21 @@ extern void gorocksdb_destruct_handler(void* id);
 
 /* Comparator */
 
-extern rocksdb_comparator_t* gorocksdb_comparator_create(size_t id);
+extern rocksdb_comparator_t* gorocksdb_comparator_create(void* state);
 
 /* Filter Policy */
 
-extern rocksdb_filterpolicy_t* gorocksdb_filterpolicy_create(size_t id);
-extern void gorocksdb_filterpolicy_delete_filter(void* id, const char* v, size_t s);
+extern rocksdb_filterpolicy_t* gorocksdb_filterpolicy_create(void* state);
+extern void gorocksdb_filterpolicy_delete_filter(void* state, const char* v, size_t s);
 
 /* Merge Operator */
 
-extern rocksdb_mergeoperator_t* gorocksdb_mergeoperator_create(size_t id);
-extern void gorocksdb_mergeoperator_delete_value(void* id, const char* v, size_t s);
+extern rocksdb_mergeoperator_t* gorocksdb_mergeoperator_create(void* state);
+extern void gorocksdb_mergeoperator_delete_value(void* state, const char* v, size_t s);
 
 /* Slice Transform */
 
-extern rocksdb_slicetransform_t* gorocksdb_slicetransform_create(size_t id);
+extern rocksdb_slicetransform_t* gorocksdb_slicetransform_create(void* state);
 
 /* Hacks */
 

--- a/merge_operator.go
+++ b/merge_operator.go
@@ -3,9 +3,9 @@ package gorocksdb
 // #include "rocksdb/c.h"
 // #include "gorocksdb.h"
 import "C"
-
-var moHandlers = make(map[int]MergeOperatorHandler)
-var moNextId int
+import (
+	"unsafe"
+)
 
 // The Merge Operator
 //
@@ -59,11 +59,8 @@ type MergeOperatorHandler interface {
 
 // NewMergeOperator creates a new merge operator for the given handler.
 func NewMergeOperator(handler MergeOperatorHandler) *MergeOperator {
-	moNextId++
-	id := moNextId
-	moHandlers[id] = handler
-
-	return NewNativeMergeOperator(C.gorocksdb_mergeoperator_create(C.size_t(id)))
+	h := unsafe.Pointer(&handler)
+	return NewNativeMergeOperator(C.gorocksdb_mergeoperator_create(h))
 }
 
 // NewNativeMergeOperator allocates a MergeOperator object.
@@ -78,7 +75,7 @@ func (self *MergeOperator) Destroy() {
 }
 
 //export gorocksdb_mergeoperator_full_merge
-func gorocksdb_mergeoperator_full_merge(id int, cKey *C.char, cKeyLen C.size_t, cExistingValue *C.char, cExistingValueLen C.size_t, cOperands **C.char, cOperandsLen *C.size_t, cNumOperands C.int, cSuccess *C.uchar, cNewValueLen *C.size_t) *C.char {
+func gorocksdb_mergeoperator_full_merge(handler *MergeOperatorHandler, cKey *C.char, cKeyLen C.size_t, cExistingValue *C.char, cExistingValueLen C.size_t, cOperands **C.char, cOperandsLen *C.size_t, cNumOperands C.int, cSuccess *C.uchar, cNewValueLen *C.size_t) *C.char {
 	key := CharToByte(cKey, cKeyLen)
 	existingValue := CharToByte(cExistingValue, cExistingValueLen)
 	operands := make([][]byte, int(cNumOperands))
@@ -89,8 +86,7 @@ func gorocksdb_mergeoperator_full_merge(id int, cKey *C.char, cKeyLen C.size_t, 
 		operands[i] = CharToByte(cOperand, cOperandLen)
 	}
 
-	handler := moHandlers[id]
-	newValue, success := handler.FullMerge(key, existingValue, operands)
+	newValue, success := (*handler).FullMerge(key, existingValue, operands)
 	newValueLen := len(newValue)
 
 	*cNewValueLen = C.size_t(newValueLen)
@@ -100,7 +96,7 @@ func gorocksdb_mergeoperator_full_merge(id int, cKey *C.char, cKeyLen C.size_t, 
 }
 
 //export gorocksdb_mergeoperator_partial_merge_multi
-func gorocksdb_mergeoperator_partial_merge_multi(id int, cKey *C.char, cKeyLen C.size_t, cOperands **C.char, cOperandsLen *C.size_t, cNumOperands C.int, cSuccess *C.uchar, cNewValueLen *C.size_t) *C.char {
+func gorocksdb_mergeoperator_partial_merge_multi(handler *MergeOperatorHandler, cKey *C.char, cKeyLen C.size_t, cOperands **C.char, cOperandsLen *C.size_t, cNumOperands C.int, cSuccess *C.uchar, cNewValueLen *C.size_t) *C.char {
 	key := CharToByte(cKey, cKeyLen)
 	operands := make([][]byte, int(cNumOperands))
 	for i, l := 0, int(cNumOperands); i < l; i++ {
@@ -113,10 +109,10 @@ func gorocksdb_mergeoperator_partial_merge_multi(id int, cKey *C.char, cKeyLen C
 	var newValue []byte
 	success := true
 
-	handler := moHandlers[id]
 	leftOperand := operands[0]
+	h := *handler
 	for i := 1; i < int(cNumOperands); i++ {
-		newValue, success = handler.PartialMerge(key, leftOperand, operands[i])
+		newValue, success = h.PartialMerge(key, leftOperand, operands[i])
 		if !success {
 			break
 		}
@@ -131,8 +127,6 @@ func gorocksdb_mergeoperator_partial_merge_multi(id int, cKey *C.char, cKeyLen C
 }
 
 //export gorocksdb_mergeoperator_name
-func gorocksdb_mergeoperator_name(id int) *C.char {
-	handler := moHandlers[id]
-
-	return StringToChar(handler.Name())
+func gorocksdb_mergeoperator_name(handler *MergeOperatorHandler) *C.char {
+	return StringToChar((*handler).Name())
 }


### PR DESCRIPTION
Previously various handlers were stored in maps with IDs, but because there was
no synchronization, it meant that some functions were not safe for concurrent
use.

Rather than add synchronization, I've removed the maps and used pointers
instead of IDs. This is concurrency-safe and cheaper since no
map lookups are required.
