### PR TITLE
Add iterator test, fix invalid free of slice memory

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -56,7 +56,7 @@ func (self *Iterator) Key() *Slice {
 		return nil
 	}
 
-	return NewSlice(cKey, cLen)
+	return &Slice{cKey, cLen, true}
 }
 
 // Value returns the value in the database the iterator currently holds.
@@ -67,7 +67,7 @@ func (self *Iterator) Value() *Slice {
 		return nil
 	}
 
-	return NewSlice(cVal, cLen)
+	return &Slice{cVal, cLen, true}
 }
 
 // Next moves the iterator to the next sequential key in the database.

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1,0 +1,49 @@
+package gorocksdb
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"os"
+	"testing"
+)
+
+func TestIterator(t *testing.T) {
+	dbName := os.TempDir() + "/TestIterator"
+
+	Convey("Subject: Iterator", t, func() {
+		options := NewDefaultOptions()
+		DestroyDb(dbName, options)
+		options.SetCreateIfMissing(true)
+
+		db, err := OpenDb(options, dbName)
+		So(err, ShouldBeNil)
+
+		Convey("When freeing iterator data, it should not panic", func() {
+			wo := NewDefaultWriteOptions()
+			So(db.Put(wo, []byte("key1"), []byte("value1")), ShouldBeNil)
+			So(db.Put(wo, []byte("key2"), []byte("value2")), ShouldBeNil)
+
+			ro := NewDefaultReadOptions()
+			iter := db.NewIterator(ro)
+			iter.Seek(nil)
+			So(iter.Valid(), ShouldBeTrue)
+			key := iter.Key()
+			So(string(key.Data()), ShouldEqual, "key1")
+			key.Free()
+			val := iter.Value()
+			So(string(val.Data()), ShouldEqual, "value1")
+			val.Free()
+
+			iter.Next()
+			So(iter.Valid(), ShouldBeTrue)
+			key = iter.Key()
+			So(string(key.Data()), ShouldEqual, "key2")
+			key.Free()
+			val = iter.Value()
+			So(string(val.Data()), ShouldEqual, "value2")
+			val.Free()
+
+			iter.Next()
+			So(iter.Valid(), ShouldBeFalse)
+		})
+	})
+}


### PR DESCRIPTION
Keys and values returned from iterators are not allocated by malloc and are
not owned by the caller, so calls to free cause problems.
