### PR TITLE
Export only interfaces for several types

### DIFF
--- a/comparator.go
+++ b/comparator.go
@@ -1,20 +1,11 @@
 package gorocksdb
 
 // #include "rocksdb/c.h"
-// #include "gorocksdb.h"
 import "C"
-import (
-	"unsafe"
-)
 
 // A Comparator object provides a total order across slices that are
 // used as keys in an sstable or a database.
-type Comparator struct {
-	c       *C.rocksdb_comparator_t
-	handler unsafe.Pointer
-}
-
-type ComparatorHandler interface {
+type Comparator interface {
 	// Three-way comparison. Returns value:
 	//   < 0 iff "a" < "b",
 	//   == 0 iff "a" == "b",
@@ -25,25 +16,23 @@ type ComparatorHandler interface {
 	Name() string
 }
 
-// NewComparator creates a new comparator for the given handler.
-func NewComparator(handler ComparatorHandler) *Comparator {
-	h := unsafe.Pointer(&handler)
-	return &Comparator{c: C.gorocksdb_comparator_create(h), handler: h}
+type nativeComparator struct {
+	c *C.rocksdb_comparator_t
 }
+
+func (c nativeComparator) Compare(a, b []byte) int { return 0 }
+
+func (c nativeComparator) Name() string { return "" }
 
 // NewNativeComparator allocates a Comparator object.
-func NewNativeComparator(c *C.rocksdb_comparator_t) *Comparator {
-	return &Comparator{c: c}
-}
-
-// Destroy deallocates the Comparator object.
-func (self *Comparator) Destroy() {
-	C.rocksdb_comparator_destroy(self.c)
-	self.c, self.handler = nil, nil
+// The Comparator's methods are no-ops, but it is still used correctly by
+// RocksDB.
+func NewNativeComparator(c *C.rocksdb_comparator_t) Comparator {
+	return nativeComparator{c}
 }
 
 //export gorocksdb_comparator_compare
-func gorocksdb_comparator_compare(handler *ComparatorHandler, cKeyA *C.char, cKeyALen C.size_t, cKeyB *C.char, cKeyBLen C.size_t) C.int {
+func gorocksdb_comparator_compare(handler *Comparator, cKeyA *C.char, cKeyALen C.size_t, cKeyB *C.char, cKeyBLen C.size_t) C.int {
 	keyA := charToByte(cKeyA, cKeyALen)
 	keyB := charToByte(cKeyB, cKeyBLen)
 
@@ -53,6 +42,6 @@ func gorocksdb_comparator_compare(handler *ComparatorHandler, cKeyA *C.char, cKe
 }
 
 //export gorocksdb_comparator_name
-func gorocksdb_comparator_name(handler *ComparatorHandler) *C.char {
+func gorocksdb_comparator_name(handler *Comparator) *C.char {
 	return stringToChar((*handler).Name())
 }

--- a/comparator_test.go
+++ b/comparator_test.go
@@ -7,18 +7,18 @@ import (
 	"testing"
 )
 
-type testComparatorHandler struct {
+type testComparator struct {
 	numCompared int
 	initiated   bool
 }
 
-func (self *testComparatorHandler) Compare(a, b []byte) int {
+func (self *testComparator) Compare(a, b []byte) int {
 	self.numCompared++
 
 	return bytes.Compare(a, b)
 }
 
-func (self *testComparatorHandler) Name() string {
+func (self *testComparator) Name() string {
 	self.initiated = true
 	return "gorocksdb.test"
 }
@@ -27,27 +27,23 @@ func TestNewComparator(t *testing.T) {
 	dbName := os.TempDir() + "/TestNewComparator"
 
 	Convey("Subject: Custom comparator", t, func() {
-		Convey("When create a custom comparator then it should not panic", func() {
-			handler := &testComparatorHandler{}
-			cmp := NewComparator(handler)
+		Convey("When passed to the db as comperator then it should not panic", func() {
+			cmp := &testComparator{}
+			options := NewDefaultOptions()
+			DestroyDb(dbName, options)
+			options.SetCreateIfMissing(true)
+			options.SetComparator(cmp)
 
-			Convey("When passed to the db as comperator then it should not panic", func() {
-				options := NewDefaultOptions()
-				DestroyDb(dbName, options)
-				options.SetCreateIfMissing(true)
-				options.SetComparator(cmp)
+			db, err := OpenDb(options, dbName)
+			So(err, ShouldBeNil)
+			So(cmp.initiated, ShouldBeTrue)
 
-				db, err := OpenDb(options, dbName)
-				So(err, ShouldBeNil)
-				So(handler.initiated, ShouldBeTrue)
-
-				Convey("When put 3 values into the db then the comperator should be called two times", func() {
-					wo := NewDefaultWriteOptions()
-					So(db.Put(wo, []byte("key1"), []byte("value1")), ShouldBeNil)
-					So(db.Put(wo, []byte("key2"), []byte("value2")), ShouldBeNil)
-					So(db.Put(wo, []byte("key3"), []byte("value3")), ShouldBeNil)
-					So(handler.numCompared, ShouldEqual, 2)
-				})
+			Convey("When put 3 values into the db then the comperator should be called two times", func() {
+				wo := NewDefaultWriteOptions()
+				So(db.Put(wo, []byte("key1"), []byte("value1")), ShouldBeNil)
+				So(db.Put(wo, []byte("key2"), []byte("value2")), ShouldBeNil)
+				So(db.Put(wo, []byte("key3"), []byte("value3")), ShouldBeNil)
+				So(cmp.numCompared, ShouldEqual, 2)
 			})
 		})
 	})

--- a/filter_policy.go
+++ b/filter_policy.go
@@ -1,20 +1,11 @@
 package gorocksdb
 
 // #include "rocksdb/c.h"
-// #include "gorocksdb.h"
 import "C"
-import (
-	"unsafe"
-)
 
 // FilterPolicy is a factory type that allows the RocksDB database to create a
 // filter, such as a bloom filter, which will used to reduce reads.
-type FilterPolicy struct {
-	c       *C.rocksdb_filterpolicy_t
-	handler unsafe.Pointer
-}
-
-type FilterPolicyHandler interface {
+type FilterPolicy interface {
 	// keys contains a list of keys (potentially with duplicates)
 	// that are ordered according to the user supplied comparator.
 	CreateFilter(keys [][]byte) []byte
@@ -30,11 +21,17 @@ type FilterPolicyHandler interface {
 	Name() string
 }
 
-// NewFilterPolicy creates a new filter policy for the given handler.
-func NewFilterPolicy(handler FilterPolicyHandler) *FilterPolicy {
-	h := unsafe.Pointer(&handler)
-	return &FilterPolicy{c: C.gorocksdb_filterpolicy_create(h), handler: h}
+// This type is a bit of a hack and will not behave as expected if clients try to
+// call its methods. It is handled specially in Options.
+type nativeFilterPolicy struct {
+	c *C.rocksdb_filterpolicy_t
 }
+
+func (fp nativeFilterPolicy) CreateFilter(keys [][]byte) []byte { return nil }
+
+func (fp nativeFilterPolicy) KeyMayMatch(key []byte, filter []byte) bool { return false }
+
+func (fp nativeFilterPolicy) Name() string { return "" }
 
 // Return a new filter policy that uses a bloom filter with approximately
 // the specified number of bits per key.  A good value for bits_per_key
@@ -47,23 +44,19 @@ func NewFilterPolicy(handler FilterPolicyHandler) *FilterPolicy {
 // ignores trailing spaces, it would be incorrect to use a
 // FilterPolicy (like NewBloomFilterPolicy) that does not ignore
 // trailing spaces in keys.
-func NewBloomFilter(bitsPerKey int) *FilterPolicy {
+func NewBloomFilter(bitsPerKey int) FilterPolicy {
 	return NewNativeFilterPolicy(C.rocksdb_filterpolicy_create_bloom(C.int(bitsPerKey)))
 }
 
 // NewNativeFilterPolicy creates a filter policy object.
-func NewNativeFilterPolicy(c *C.rocksdb_filterpolicy_t) *FilterPolicy {
-	return &FilterPolicy{c: c}
-}
-
-// Destroy deallocates the FilterPolicy object.
-func (self *FilterPolicy) Destroy() {
-	C.rocksdb_filterpolicy_destroy(self.c)
-	self.c, self.handler = nil, nil
+// The FilterPolicy's methods are no-ops, but it is still used correctly by
+// RocksDB.
+func NewNativeFilterPolicy(c *C.rocksdb_filterpolicy_t) FilterPolicy {
+	return nativeFilterPolicy{c}
 }
 
 //export gorocksdb_filterpolicy_create_filter
-func gorocksdb_filterpolicy_create_filter(handler *FilterPolicyHandler, cKeys **C.char, cKeysLen *C.size_t, cNumKeys C.int, cDstLen *C.size_t) *C.char {
+func gorocksdb_filterpolicy_create_filter(handler *FilterPolicy, cKeys **C.char, cKeysLen *C.size_t, cNumKeys C.int, cDstLen *C.size_t) *C.char {
 	rawKeys := charSlice(cKeys, cNumKeys)
 	keysLen := sizeSlice(cKeysLen, cNumKeys)
 	keys := make([][]byte, int(cNumKeys))
@@ -79,7 +72,7 @@ func gorocksdb_filterpolicy_create_filter(handler *FilterPolicyHandler, cKeys **
 }
 
 //export gorocksdb_filterpolicy_key_may_match
-func gorocksdb_filterpolicy_key_may_match(handler *FilterPolicyHandler, cKey *C.char, cKeyLen C.size_t, cFilter *C.char, cFilterLen C.size_t) C.uchar {
+func gorocksdb_filterpolicy_key_may_match(handler *FilterPolicy, cKey *C.char, cKeyLen C.size_t, cFilter *C.char, cFilterLen C.size_t) C.uchar {
 	key := charToByte(cKey, cKeyLen)
 	filter := charToByte(cFilter, cFilterLen)
 
@@ -89,6 +82,6 @@ func gorocksdb_filterpolicy_key_may_match(handler *FilterPolicyHandler, cKey *C.
 }
 
 //export gorocksdb_filterpolicy_name
-func gorocksdb_filterpolicy_name(handler *FilterPolicyHandler) *C.char {
+func gorocksdb_filterpolicy_name(handler *FilterPolicy) *C.char {
 	return stringToChar((*handler).Name())
 }

--- a/slice_transform_test.go
+++ b/slice_transform_test.go
@@ -6,23 +6,23 @@ import (
 	"testing"
 )
 
-type testSliceTransformHandler struct {
+type testSliceTransform struct {
 	initiated bool
 }
 
-func (self *testSliceTransformHandler) Transform(src []byte) []byte {
+func (self *testSliceTransform) Transform(src []byte) []byte {
 	return src[0:3]
 }
 
-func (self *testSliceTransformHandler) InDomain(src []byte) bool {
+func (self *testSliceTransform) InDomain(src []byte) bool {
 	return len(src) >= 3
 }
 
-func (self *testSliceTransformHandler) InRange(src []byte) bool {
+func (self *testSliceTransform) InRange(src []byte) bool {
 	return len(src) == 3
 }
 
-func (self *testSliceTransformHandler) Name() string {
+func (self *testSliceTransform) Name() string {
 	self.initiated = true
 	return "gorocksdb.test"
 }
@@ -31,8 +31,7 @@ func TestCustomSliceTransform(t *testing.T) {
 	dbName := os.TempDir() + "/TestNewSliceTransform"
 
 	Convey("Subject: Prefix filtering with custom slice transform", t, func() {
-		handler := &testSliceTransformHandler{}
-		sliceTransform := NewSliceTransform(handler)
+		sliceTransform := &testSliceTransform{}
 
 		options := NewDefaultOptions()
 		DestroyDb(dbName, options)


### PR DESCRIPTION
Specifically:
- Comparators
- Filter policies
- Merge operators
- Slice transforms

This makes the API simpler.
