### PR TITLE
updates for 3.5, null terminated some strings

### DIFF
--- a/db.go
+++ b/db.go
@@ -36,7 +36,9 @@ type DB struct {
 // OpenDb opens a database with the specified options.
 func OpenDb(opts *Options, name string) (*DB, error) {
 	var cErr *C.char
-	db := C.rocksdb_open(opts.c, stringToChar(name), &cErr)
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	db := C.rocksdb_open(opts.c, cname, &cErr)
 	if cErr != nil {
 		defer C.free(unsafe.Pointer(cErr))
 
@@ -53,7 +55,9 @@ func OpenDb(opts *Options, name string) (*DB, error) {
 // OpenDbForReadOnly opens a database with the specified options for readonly usage.
 func OpenDbForReadOnly(opts *Options, name string, errorIfLogFileExist bool) (*DB, error) {
 	var cErr *C.char
-	db := C.rocksdb_open_for_read_only(opts.c, stringToChar(name), boolToChar(errorIfLogFileExist), &cErr)
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	db := C.rocksdb_open_for_read_only(opts.c, cname, boolToChar(errorIfLogFileExist), &cErr)
 	if cErr != nil {
 		defer C.free(unsafe.Pointer(cErr))
 
@@ -165,7 +169,9 @@ func (self *DB) NewSnapshot() *Snapshot {
 
 // GetProperty returns the value of a database property.
 func (self *DB) GetProperty(propName string) string {
-	cValue := C.rocksdb_property_value(self.c, stringToChar(propName))
+	cprop := C.CString(propName)
+	defer C.free(unsafe.Pointer(cprop))
+	cValue := C.rocksdb_property_value(self.c, cprop)
 	defer C.free(unsafe.Pointer(cValue))
 
 	return C.GoString(cValue)
@@ -276,7 +282,9 @@ func (self *DB) EnableFileDeletions(force bool) error {
 // reflect that. Supports deletion of sst and log files only. 'name' must be
 // path relative to the db directory. eg. 000001.sst, /archive/000003.log.
 func (self *DB) DeleteFile(name string) {
-	C.rocksdb_delete_file(self.c, stringToChar(name))
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	C.rocksdb_delete_file(self.c, cname)
 }
 
 // Close closes the database.
@@ -288,7 +296,9 @@ func (self *DB) Close() {
 // filesystem.
 func DestroyDb(name string, opts *Options) error {
 	var cErr *C.char
-	C.rocksdb_destroy_db(opts.c, stringToChar(name), &cErr)
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	C.rocksdb_destroy_db(opts.c, cname, &cErr)
 	if cErr != nil {
 		defer C.free(unsafe.Pointer(cErr))
 
@@ -301,7 +311,9 @@ func DestroyDb(name string, opts *Options) error {
 // RepairDb repairs a database.
 func RepairDb(name string, opts *Options) error {
 	var cErr *C.char
-	C.rocksdb_repair_db(opts.c, stringToChar(name), &cErr)
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	C.rocksdb_repair_db(opts.c, cname, &cErr)
 	if cErr != nil {
 		defer C.free(unsafe.Pointer(cErr))
 

--- a/filter_policy_test.go
+++ b/filter_policy_test.go
@@ -2,9 +2,10 @@ package gorocksdb
 
 import (
 	"bytes"
-	. "github.com/smartystreets/goconvey/convey"
 	"os"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 type testFilterPolicy struct {
@@ -40,7 +41,9 @@ func TestNewFilterPolicy(t *testing.T) {
 			options := NewDefaultOptions()
 			DestroyDb(dbName, options)
 			options.SetCreateIfMissing(true)
-			options.SetFilterPolicy(policy)
+			boptions := NewDefaultBlockBasedTableOptions()
+			boptions.SetFilterPolicy(policy)
+			options.SetBlockBasedTableFactory(boptions)
 
 			db, err := OpenDb(options, dbName)
 			So(err, ShouldBeNil)

--- a/merge_operator.go
+++ b/merge_operator.go
@@ -53,9 +53,13 @@ type nativeMergeOperator struct {
 	c *C.rocksdb_mergeoperator_t
 }
 
-func (mo nativeMergeOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) { return nil, false }
+func (mo nativeMergeOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
+	return nil, false
+}
 
-func (mo nativeMergeOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) { return nil, false }
+func (mo nativeMergeOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) {
+	return nil, false
+}
 
 func (mo nativeMergeOperator) Name() string { return "" }
 

--- a/merge_operator_test.go
+++ b/merge_operator_test.go
@@ -1,9 +1,10 @@
 package gorocksdb
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"os"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 type testMergeOperator struct {

--- a/options_block_based_table.go
+++ b/options_block_based_table.go
@@ -1,0 +1,120 @@
+package gorocksdb
+
+// #include "rocksdb/c.h"
+// #include "gorocksdb.h"
+import "C"
+import (
+	"unsafe"
+)
+
+// Block-based table related options are moved to BlockBasedTableOptions.
+// If you'd like to customize some of these options, you will need to
+// use NewBlockBasedTableFactory() to construct a new table factory.
+// For advanced user only
+type BlockBasedTableOptions struct {
+	c *C.rocksdb_block_based_table_options_t
+
+	// hold references for GC
+	cache      *Cache
+	comp_cache *Cache
+	fp         *FilterPolicy
+
+	// Hold on so memory can be freed in Destroy.
+	cfp *C.rocksdb_filterpolicy_t
+}
+
+// NewDefaultBlockBasedTableOptions creates a default BlockBasedTableOptions object.
+func NewDefaultBlockBasedTableOptions() *BlockBasedTableOptions {
+	return NewNativeBlockBasedTableOptions(C.rocksdb_block_based_options_create())
+}
+
+// NewNativeBlockBasedTableOptions creates a BlockBasedTableOptions object.
+func NewNativeBlockBasedTableOptions(c *C.rocksdb_block_based_table_options_t) *BlockBasedTableOptions {
+	return &BlockBasedTableOptions{c: c}
+}
+
+// Destroy deallocates the BlockBasedTableOptions object.
+func (self *BlockBasedTableOptions) Destroy() {
+	C.rocksdb_block_based_options_destroy(self.c)
+	self.c = nil
+	self.fp = nil
+	self.cache = nil
+	self.comp_cache = nil
+}
+
+// Approximate size of user data packed per block. Note that the
+// block size specified here corresponds to uncompressed data. The
+// actual size of the unit read from disk may be smaller if
+// compression is enabled. This parameter can be changed dynamically.
+// Default: 4K
+func (self *BlockBasedTableOptions) SetBlockSize(block_size int) {
+	C.rocksdb_block_based_options_set_block_size(self.c, C.size_t(block_size))
+}
+
+// This is used to close a block before it reaches the configured
+// 'block_size'. If the percentage of free space in the current block is less
+// than this specified number and adding a new record to the block will
+// exceed the configured block size, then this block will be closed and the
+// new record will be written to the next block.
+// Default: 10
+func (self *BlockBasedTableOptions) SetBlockSizeDeviation(block_size_deviation int) {
+	C.rocksdb_block_based_options_set_block_size_deviation(self.c, C.int(block_size_deviation))
+}
+
+// Number of keys between restart points for delta encoding of keys.
+// This parameter can be changed dynamically. Most clients should
+// leave this parameter alone.
+// Default: 16
+func (self *BlockBasedTableOptions) SetBlockRestartInterval(block_restart_interval int) {
+	C.rocksdb_block_based_options_set_block_restart_interval(self.c, C.int(block_restart_interval))
+}
+
+// If set use the specified filter policy to reduce disk reads.
+// Many applications will benefit from passing the result of
+// NewBloomFilterPolicy() here.
+// Default: nil
+func (self *BlockBasedTableOptions) SetFilterPolicy(value FilterPolicy) {
+	if nfp, ok := value.(nativeFilterPolicy); ok {
+		self.cfp = nfp.c
+	} else {
+		h := unsafe.Pointer(&value)
+		self.fp = &value
+		self.cfp = C.gorocksdb_filterpolicy_create(h)
+	}
+	C.rocksdb_block_based_options_set_filter_policy(self.c, self.cfp)
+}
+
+// Disable block cache. If this is set to true, then no block cache
+// should be used.
+// Default: false
+func (self *BlockBasedTableOptions) SetNoBlockCache(value bool) {
+	C.rocksdb_block_based_options_set_no_block_cache(self.c, boolToChar(value))
+}
+
+// Control over blocks (user data is stored in a set of blocks, and
+// a block is the unit of reading from disk).
+//
+// If set, use the specified cache for blocks.
+// If nil, rocksdb will automatically create and use an 8MB internal cache.
+// Default: nil
+func (self *BlockBasedTableOptions) SetBlockCache(value *Cache) {
+	self.cache = value
+
+	C.rocksdb_block_based_options_set_block_cache(self.c, value.c)
+}
+
+// If set, use the specified cache for compressed blocks.
+// If nil, rocksdb will not use a compressed block cache.
+// Default: nil
+func (self *BlockBasedTableOptions) SetBlockCacheCompressed(value *Cache) {
+	self.comp_cache = value
+
+	C.rocksdb_block_based_options_set_block_cache_compressed(self.c, value.c)
+}
+
+// If true, place whole keys in the filter (not just prefixes).
+// This must generally be true for gets to be efficient.
+// Default: true
+func (self *BlockBasedTableOptions) SetWholeKeyFiltering(value bool) {
+	C.rocksdb_block_based_options_set_whole_key_filtering(self.c, boolToChar(value))
+}

--- a/slice_transform_test.go
+++ b/slice_transform_test.go
@@ -1,9 +1,10 @@
 package gorocksdb
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"os"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 type testSliceTransform struct {
@@ -36,9 +37,10 @@ func TestCustomSliceTransform(t *testing.T) {
 		options := NewDefaultOptions()
 		DestroyDb(dbName, options)
 
-		options.SetFilterPolicy(NewBloomFilter(10))
 		options.SetPrefixExtractor(sliceTransform)
 		options.SetHashSkipListRep(50000, 4, 4)
+		options.SetAllowMmapReads(true)
+		options.SetAllowMmapWrites(true)
 		options.SetPlainTableFactory(4, 10, 0.75, 16)
 		options.SetCreateIfMissing(true)
 
@@ -76,8 +78,9 @@ func TestFixedPrefixTransform(t *testing.T) {
 		options := NewDefaultOptions()
 		DestroyDb(dbName, options)
 
-		options.SetFilterPolicy(NewBloomFilter(10))
 		options.SetHashSkipListRep(50000, 4, 4)
+		options.SetAllowMmapReads(true)
+		options.SetAllowMmapWrites(true)
 		options.SetPlainTableFactory(4, 10, 0.75, 16)
 		options.SetCreateIfMissing(true)
 


### PR DESCRIPTION
Patch mostly adds support for latest 3.5 BlockBasedTableOptions which
deprecates some normal options.

Also found that stringToChar() is not properly null terminating strings.
Not all uses are fixed, mostly because the ones remaining are tricky.
This was causing some issues in opening the database mostly, the
directory would change names on occasion and start fresh. Relevant issue
here: https://github.com/facebook/rocksdb/issues/332#issuecomment-57893418

couple files got caught by gofmt, if that bothers you I will gladly
remove them from the patch and resubmit.
