### PR TITLE
Update iterator.go

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -45,7 +45,10 @@ func (self *Iterator) Valid() bool {
 // ValidForPrefix returns false only when an Iterator has iterated past the
 // first or the last key in the database or the specified prefix.
 func (self *Iterator) ValidForPrefix(prefix []byte) bool {
-	return C.rocksdb_iter_valid(self.c) != 0 && bytes.HasPrefix(self.Key().Data(), prefix)
+	keySlice := self.Key()
+	key := keySlice.Data()
+	defer keySlice.Free()
+	return C.rocksdb_iter_valid(self.c) != 0 && bytes.HasPrefix(key, prefix)
 }
 
 // Key returns the key the iterator currently holds.


### PR DESCRIPTION
I suspect there's a memory leak for key slice that is not freed so I suggest following fix.  But on the other hand there's also an example in the source https://github.com/tecbot/gorocksdb/blob/master/iterator.go#L23 that also does not call Free(). So what is safe approach here? Is it ok not to Free() keySlice?