### PR TITLE
embed mode using cockroachdb packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.2
+  - 1.5
   - release
   - tip
 
@@ -23,10 +24,12 @@ install:
   - sudo cp --preserve=links ./librocksdb.* /usr/lib/
   - sudo cp -r ./include/rocksdb/ /usr/include/
   - popd
-  - go get -t ./...
+  - go get -t -tags dynamic ./...
+  - go version|grep go1.5 > /dev/null && go get -t -tags embed ./... || true
 
 script:
-  - go test -v ./
+  - go test -v -tags dynamic ./
+  - go version|grep go1.5 > /dev/null && go test -v -tags embed ./ || true
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -11,4 +11,6 @@ You'll need the shared library build of
 
 Now, if you build RocksDB you can install gorocksdb:
 
-    CGO_CFLAGS="-I/path/to/rocksdb/include" CGO_LDFLAGS="-L/path/to/rocksdb" go get github.com/tecbot/gorocksdb
+    CGO_CFLAGS="-I/path/to/rocksdb/include" \
+    CGO_LDFLAGS="-L/path/to/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" \
+      go get github.com/tecbot/gorocksdb

--- a/backup.go
+++ b/backup.go
@@ -1,6 +1,5 @@
 package gorocksdb
 
-// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy
 // #include <stdlib.h>
 // #include "rocksdb/c.h"
 import "C"

--- a/db.go
+++ b/db.go
@@ -1,6 +1,5 @@
 package gorocksdb
 
-// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy
 // #include <stdlib.h>
 // #include "rocksdb/c.h"
 import "C"

--- a/dynflag.go
+++ b/dynflag.go
@@ -1,0 +1,6 @@
+// +build dynamic
+
+package gorocksdb
+
+// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy
+import "C"

--- a/embedflag.go
+++ b/embedflag.go
@@ -1,0 +1,18 @@
+// +build embed
+
+package gorocksdb
+
+// #cgo CXXFLAGS: -std=c++11
+// #cgo CPPFLAGS: -I${SRCDIR}/../../cockroachdb/c-lz4/internal/lib
+// #cgo CPPFLAGS: -I${SRCDIR}/../../cockroachdb/c-rocksdb/internal/include
+// #cgo CPPFLAGS: -I${SRCDIR}/../../cockroachdb/c-snappy/internal
+// #cgo LDFLAGS: -lstdc++ -lrt
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+import "C"
+
+import (
+	_ "github.com/cockroachdb/c-lz4"
+	_ "github.com/cockroachdb/c-rocksdb"
+	_ "github.com/cockroachdb/c-snappy"
+)


### PR DESCRIPTION
Currently the `gorocksdb` package requires dynamic linking because of the `LDFLAGS` it configures within the package. For our use case we statically link our rocksdb library. To support this we currently have to use a forked version of the package that simply removes those two `LDFLAGS` stanzas. We'd like to stop having to keep our fork updated, so this pull request enables a few new modes:

1. `-tags dynamic` provides the existing behavior. It adds the same `LDFLAGS`.
1. `-tags embed` provides a new mode which provides a `go get` friendly embedded rocksdb library. This is based on the awesome work of the @cockroachdb team.
1. Finally no tags now defaults to no flags. In this mode it is up to the package consumer to make the rockdb library available. (We use this internally.)

In theory the travis CI config could be greatly simplified by using the `embed` mode -- but for now I've added testing using that mode _in addition to_ the existing dynamic testing since that tests against rocksdb master is desirable.