### PR TITLE
[unsafe] return underlying c rocksdb instance

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -102,8 +102,8 @@ func OpenBackupEngine(opts *Options, path string) (*BackupEngine, error) {
 }
 
 // UnsafeGetBackupEngine returns the underlying c backup engine
-func (self *BackupEngine) UnsafeGetBackupEngine() *C.rocksdb_backup_engine_t {
-	return self.c
+func (self *BackupEngine) UnsafeGetBackupEngine() unsafe.Pointer {
+	return unsafe.Pointer(self.c)
 }
 
 // CreateNewBackup takes a new backup from @db

--- a/backup.go
+++ b/backup.go
@@ -101,6 +101,11 @@ func OpenBackupEngine(opts *Options, path string) (*BackupEngine, error) {
 	}, nil
 }
 
+// UnsafeGetBackupEngine returns the underlying c backup engine
+func (self *BackupEngine) UnsafeGetBackupEngine() *C.rocksdb_backup_engine_t {
+	return self.c
+}
+
 // CreateNewBackup takes a new backup from @db
 func (self *BackupEngine) CreateNewBackup(db *DB) error {
 	var cErr *C.char

--- a/cf_handle.go
+++ b/cf_handle.go
@@ -13,6 +13,12 @@ func NewNativeColumnFamilyHandle(c *C.rocksdb_column_family_handle_t) *ColumnFam
 	return &ColumnFamilyHandle{c}
 }
 
+// UnsafeGetCFHandler returns the underlying c column family handle.
+func (h *ColumnFamilyHandle) UnsafeGetCFHandler() *C.rocksdb_column_family_handle_t {
+	return h.c
+}
+
+// Destroy calls the destructor of the underlying column family handle.
 func (h *ColumnFamilyHandle) Destroy() {
 	C.rocksdb_column_family_handle_destroy(h.c)
 }

--- a/cf_handle.go
+++ b/cf_handle.go
@@ -3,6 +3,7 @@ package gorocksdb
 // #include <stdlib.h>
 // #include "rocksdb/c.h"
 import "C"
+import "unsafe"
 
 type ColumnFamilyHandle struct {
 	c *C.rocksdb_column_family_handle_t
@@ -14,8 +15,8 @@ func NewNativeColumnFamilyHandle(c *C.rocksdb_column_family_handle_t) *ColumnFam
 }
 
 // UnsafeGetCFHandler returns the underlying c column family handle.
-func (h *ColumnFamilyHandle) UnsafeGetCFHandler() *C.rocksdb_column_family_handle_t {
-	return h.c
+func (h *ColumnFamilyHandle) UnsafeGetCFHandler() unsafe.Pointer {
+	return unsafe.Pointer(h.c)
 }
 
 // Destroy calls the destructor of the underlying column family handle.

--- a/db.go
+++ b/db.go
@@ -213,8 +213,8 @@ func ListColumnFamilies(opts *Options, name string) ([]string, error) {
 }
 
 // UnsafeGetDB returns the underlying c rocksdb instance.
-func (self *DB) UnsafeGetDB() *C.rocksdb_t {
-	return self.c
+func (self *DB) UnsafeGetDB() unsafe.Pointer {
+	return unsafe.Pointer(self.c)
 }
 
 // Name returns the name of the database.

--- a/db.go
+++ b/db.go
@@ -212,6 +212,11 @@ func ListColumnFamilies(opts *Options, name string) ([]string, error) {
 	return names, nil
 }
 
+// UnsafeGetDB returns the underlying c rocksdb instance.
+func (self *DB) UnsafeGetDB() *C.rocksdb_t {
+	return self.c
+}
+
 // Name returns the name of the database.
 func (self *DB) Name() string {
 	return self.name
@@ -372,14 +377,14 @@ func (self *DB) Write(opts *WriteOptions, batch *WriteBatch) error {
 // ReadOptions given.
 func (self *DB) NewIterator(opts *ReadOptions) *Iterator {
 	cIter := C.rocksdb_create_iterator(self.c, opts.c)
-	return NewNativeIterator(cIter)
+	return NewNativeIterator(unsafe.Pointer(cIter))
 }
 
 // NewIteratorCF returns an Iterator over the the database and column family
 // that uses the ReadOptions given.
 func (self *DB) NewIteratorCF(opts *ReadOptions, cf *ColumnFamilyHandle) *Iterator {
 	cIter := C.rocksdb_create_iterator_cf(self.c, opts.c, cf.c)
-	return NewNativeIterator(cIter)
+	return NewNativeIterator(unsafe.Pointer(cIter))
 }
 
 // NewSnapshot creates a new snapshot of the database.

--- a/iterator.go
+++ b/iterator.go
@@ -32,8 +32,8 @@ type Iterator struct {
 }
 
 // NewNativeIterator creates a Iterator object.
-func NewNativeIterator(c *C.rocksdb_iterator_t) *Iterator {
-	return &Iterator{c}
+func NewNativeIterator(c unsafe.Pointer) *Iterator {
+	return &Iterator{(*C.rocksdb_iterator_t)(c)}
 }
 
 // Valid returns false only when an Iterator has iterated past either the

--- a/options_read.go
+++ b/options_read.go
@@ -34,6 +34,11 @@ func NewNativeReadOptions(c *C.rocksdb_readoptions_t) *ReadOptions {
 	return &ReadOptions{c}
 }
 
+// UnsafeGetReadOptions returns the underlying c read options object.
+func (self *ReadOptions) UnsafeGetReadOptions() *C.rocksdb_readoptions_t {
+	return self.c
+}
+
 // If true, all data read from underlying storage will be
 // verified against corresponding checksums.
 // Default: false

--- a/options_read.go
+++ b/options_read.go
@@ -2,6 +2,7 @@ package gorocksdb
 
 // #include "rocksdb/c.h"
 import "C"
+import "unsafe"
 
 // An application can issue a read request (via Get/Iterators) and specify
 // if that read should process data that ALREADY resides on a specified cache
@@ -35,8 +36,8 @@ func NewNativeReadOptions(c *C.rocksdb_readoptions_t) *ReadOptions {
 }
 
 // UnsafeGetReadOptions returns the underlying c read options object.
-func (self *ReadOptions) UnsafeGetReadOptions() *C.rocksdb_readoptions_t {
-	return self.c
+func (self *ReadOptions) UnsafeGetReadOptions() unsafe.Pointer {
+	return unsafe.Pointer(self.c)
 }
 
 // If true, all data read from underlying storage will be


### PR DESCRIPTION
return the underlying c instances for a few gorocks structs.

We want to extend the gorocks beyond the c bindings.
For instance, for the application we are developing we we want to use some of these methods in DB object (the c++ struct in rocksdb/db.h)
NewIterators (for multi CF iterators)
PurgeOldBackups

If we get the underlying c object then we can c++ code to access those methods from our go code, while still using the awesome api provided by  gorocksdb.

an example -> 
https://github.com/pavanka/opaque-rocksdb/blob/purge/test.go
see commands for how we compile this.

however, for NewIterators seems like we need a private fork. any suggestions. 
https://github.com/pavanka/opaque-rocksdb/blob/iterators/test.go#L41
this is invalid reason: cannot use iter (type *C.struct_rocksdb_iterator_t) as type *gorocksdb.C.struct_rocksdb_iterator_t in argument to gorocksdb.NewNativeIterator