### PR TITLE
Add MaxDictBytes parameter to CompressionOptions

### DIFF
--- a/options.go
+++ b/options.go
@@ -325,7 +325,7 @@ func (opts *Options) SetMinLevelToCompress(value int) {
 // SetCompressionOptions sets different options for compression algorithms.
 // Default: nil
 func (opts *Options) SetCompressionOptions(value *CompressionOptions) {
-	C.rocksdb_options_set_compression_options(opts.c, C.int(value.WindowBits), C.int(value.Level), C.int(value.Strategy))
+	C.rocksdb_options_set_compression_options(opts.c, C.int(value.WindowBits), C.int(value.Level), C.int(value.Strategy), C.int(value.MaxDictBytes))
 }
 
 // SetPrefixExtractor sets the prefic extractor.

--- a/options_compression.go
+++ b/options_compression.go
@@ -2,21 +2,23 @@ package gorocksdb
 
 // CompressionOptions represents options for different compression algorithms like Zlib.
 type CompressionOptions struct {
-	WindowBits int
-	Level      int
-	Strategy   int
+	WindowBits   int
+	Level        int
+	Strategy     int
+	MaxDictBytes int
 }
 
 // NewDefaultCompressionOptions creates a default CompressionOptions object.
 func NewDefaultCompressionOptions() *CompressionOptions {
-	return NewCompressionOptions(-14, -1, 0)
+	return NewCompressionOptions(-14, -1, 0, 0)
 }
 
 // NewCompressionOptions creates a CompressionOptions object.
-func NewCompressionOptions(windowBits, level, strategy int) *CompressionOptions {
+func NewCompressionOptions(windowBits, level, strategy, maxDictBytes int) *CompressionOptions {
 	return &CompressionOptions{
-		WindowBits: windowBits,
-		Level:      level,
-		Strategy:   strategy,
+		WindowBits:   windowBits,
+		Level:        level,
+		Strategy:     strategy,
+		MaxDictBytes: maxDictBytes,
 	}
 }


### PR DESCRIPTION
`rocksdb_options_set_compression_options` now [takes an additional parameter](https://github.com/facebook/rocksdb/blob/c3a4bea5dcf851b0236c682bf2fa4eba85a7c125/db/c.cc#L1575) called `max_dict_bytes`.

#57 #50