### PR TITLE
added lz4 and lz4hc compression types

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ If you want to go the way with the shared library you'll need to build
 If you built RocksDB you can install gorocksdb now:
 
     CGO_CFLAGS="-I/path/to/rocksdb/include" \
-    CGO_LDFLAGS="-L/path/to/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" \
+    CGO_LDFLAGS="-L/path/to/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4" \
       go get github.com/tecbot/gorocksdb

--- a/options.go
+++ b/options.go
@@ -18,6 +18,8 @@ const (
 	SnappyCompression = CompressionType(C.rocksdb_snappy_compression)
 	ZLibCompression   = CompressionType(C.rocksdb_zlib_compression)
 	Bz2Compression    = CompressionType(C.rocksdb_bz2_compression)
+	LZ4Compression    = CompressionType(C.rocksdb_lz4_compression)
+	LZ4HCCompression  = CompressionType(C.rocksdb_lz4hc_compression)
 )
 
 // CompactionStyle specifies the compaction style.


### PR DESCRIPTION
Fixes #35 

as per https://github.com/facebook/rocksdb/blob/master/include/rocksdb/c.h#L709 , rocksdb supports lz4 and lz4hc compression options as well.