### PR TITLE
Fix issue #69; Make sure we can compile with the latest rocksdb.

### DIFF
--- a/options.go
+++ b/options.go
@@ -432,8 +432,8 @@ func (opts *Options) SetMaxBytesForLevelBase(value uint64) {
 
 // SetMaxBytesForLevelMultiplier sets the max Bytes for level multiplier.
 // Default: 10
-func (opts *Options) SetMaxBytesForLevelMultiplier(value int) {
-	C.rocksdb_options_set_max_bytes_for_level_multiplier(opts.c, C.int(value))
+func (opts *Options) SetMaxBytesForLevelMultiplier(value float64) {
+	C.rocksdb_options_set_max_bytes_for_level_multiplier(opts.c, C.double(value))
 }
 
 // SetMaxBytesForLevelMultiplierAdditional sets different max-size multipliers
@@ -449,37 +449,6 @@ func (opts *Options) SetMaxBytesForLevelMultiplierAdditional(value []int) {
 	}
 
 	C.rocksdb_options_set_max_bytes_for_level_multiplier_additional(opts.c, &cLevels[0], C.size_t(len(value)))
-}
-
-// SetExpandedCompactionFactor sets the maximum number of bytes
-// in all compacted files.
-//
-// We avoid expanding the lower level file set of a compaction
-// if it would make the total compaction cover more than
-// (expanded_compaction_factor * targetFileSizeLevel()) many bytes.
-// Default: 25
-func (opts *Options) SetExpandedCompactionFactor(value int) {
-	C.rocksdb_options_set_expanded_compaction_factor(opts.c, C.int(value))
-}
-
-// SetSourceCompactionFactor sets the maximum number of bytes
-// in all source files to be compacted in a single compaction run.
-//
-// We avoid picking too many files in the
-// source level so that we do not exceed the total source bytes
-// for compaction to exceed
-// (source_compaction_factor * targetFileSizeLevel()) many bytes.
-// Default: 1
-func (opts *Options) SetSourceCompactionFactor(value int) {
-	C.rocksdb_options_set_source_compaction_factor(opts.c, C.int(value))
-}
-
-// SetMaxGrandparentOverlapFactor sets the maximum bytes
-// of overlaps in grandparent (i.e., level+2) before we
-// stop building a single file in a level->level+1 compaction.
-// Default: 10
-func (opts *Options) SetMaxGrandparentOverlapFactor(value int) {
-	C.rocksdb_options_set_max_grandparent_overlap_factor(opts.c, C.int(value))
 }
 
 // SetDisableDataSync enable/disable data sync.


### PR DESCRIPTION
In the newest version of Rocksdb, some options have been removed
(for example: https://github.com/facebook/rocksdb/pull/1326/files)
And another option is updated to double:
https://github.com/facebook/rocksdb/pull/1427/files

To make the gorocksdb compatible with the newest rocksdb, I removed
the corresponding options and updated the multiplier option to be
double.

This should fix: https://github.com/tecbot/gorocksdb/issues/69