### PR TITLE
Add direct I/O mode options from upstream.

### DIFF
--- a/options.go
+++ b/options.go
@@ -676,14 +676,6 @@ func (opts *Options) SetPurgeRedundantKvsWhileFlush(value bool) {
 	C.rocksdb_options_set_purge_redundant_kvs_while_flush(opts.c, boolToChar(value))
 }
 
-// SetAllowOsBuffer enable/disable os buffer.
-//
-// Data being read from file storage may be buffered in the OS
-// Default: true
-func (opts *Options) SetAllowOsBuffer(value bool) {
-	C.rocksdb_options_set_allow_os_buffer(opts.c, boolToChar(value))
-}
-
 // SetAllowMmapReads enable/disable mmap reads for reading sst tables.
 // Default: false
 func (opts *Options) SetAllowMmapReads(value bool) {

--- a/options.go
+++ b/options.go
@@ -688,6 +688,18 @@ func (opts *Options) SetAllowMmapWrites(value bool) {
 	C.rocksdb_options_set_allow_mmap_writes(opts.c, boolToChar(value))
 }
 
+// SetUseDirectReads enable/disable direct I/O mode (O_DIRECT) for reads
+// Default: false
+func (opts *Options) SetUseDirectReads(value bool) {
+	C.rocksdb_options_set_use_direct_reads(opts.c, boolToChar(value))
+}
+
+// SetUseDirectWrites enable/disable direct I/O mode (O_DIRECT) for writes
+// Default: false
+func (opts *Options) SetUseDirectWrites(value bool) {
+	C.rocksdb_options_set_use_direct_writes(opts.c, boolToChar(value))
+}
+
 // SetIsFdCloseOnExec enable/dsiable child process inherit open files.
 // Default: true
 func (opts *Options) SetIsFdCloseOnExec(value bool) {


### PR DESCRIPTION
Both commits are related to https://github.com/facebook/rocksdb/commit/972f96b3fbae1a4675043bdf4279c9072ad69645.

And it also fixes the build against the rocksdb master.