### PR TITLE
Fix result from stringToChar() is not null terminated

### DIFF
--- a/util.go
+++ b/util.go
@@ -52,9 +52,10 @@ func cByteSlice(b []byte) *C.char {
 }
 
 // stringToChar returns *C.char from string.
+// The C string is allocated in the C heap using malloc. It is the
+// caller's responsibility to arrange for it to be freed.
 func stringToChar(s string) *C.char {
-	ptrStr := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	return (*C.char)(unsafe.Pointer(ptrStr.Data))
+	return C.CString(s)
 }
 
 // charSlice converts a C array of *char to a []*C.char.


### PR DESCRIPTION
Currently the C string returned from `stringToChar()` just the pointer from Go string, but not indicate how long this C string is (i.e. not null terminated). There will be problem when using this C string, e.g. print it will print not only original Go string, but also everything followed by the pointer in the memory.

This PR use `C.CString()` function from [cgo](https://golang.org/cmd/cgo/#hdr-Go_references_to_C). Its [implementation](https://github.com/golang/go/blob/6654e3e0a1fa1deff4acf7d5ea68cd078df7e2fa/src/cmd/cgo/out.go#L1434-L1442) will use `malloc()` to allocate in heap, so the caller should care about when to free the C string.