### PR TITLE
Fixup missing -lzstd

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You'll need to build [RocksDB](https://github.com/facebook/rocksdb) v5.4+ on you
 After that, you can install gorocksdb using the following command:
 
     CGO_CFLAGS="-I/path/to/rocksdb/include" \
-    CGO_LDFLAGS="-L/path/to/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4" \
+    CGO_LDFLAGS="-L/path/to/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd" \
       go get github.com/tecbot/gorocksdb
 
 Please note that this package might upgrade the required RocksDB version at any moment.


### PR DESCRIPTION
I have tried to install gorocksdb and it failed:
```bash
CGO_CFLAGS="-I/usr/local/include/rocksdb/include" CGO_LDFLAGS="-L/usr/local/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4"   go get github.com/tecbot/gorocksdb
# github.com/tecbot/gorocksdb
/usr/local/lib/librocksdb.a(db_impl.o): In function `rocksdb::ZSTD_Supported()':
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:84: undefined reference to `ZSTD_versionNumber'
/usr/local/lib/librocksdb.a(options_helper.o): In function `rocksdb::ZSTD_Supported()':
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:84: undefined reference to `ZSTD_versionNumber'
/usr/local/lib/librocksdb.a(format.o): In function `rocksdb::ZSTD_Uncompress(char const*, unsigned long, int*, rocksdb::Slice const&)':
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:775: undefined reference to `ZSTD_createDCtx'
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:778: undefined reference to `ZSTD_decompress_usingDict'
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:779: undefined reference to `ZSTD_freeDCtx'
/usr/local/lib/librocksdb.a(column_family.o): In function `rocksdb::ZSTD_Supported()':
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:84: undefined reference to `ZSTD_versionNumber'
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:84: undefined reference to `ZSTD_versionNumber'
/usr/local/lib/librocksdb.a(block_based_table_builder.o): In function `rocksdb::ZSTD_Compress(rocksdb::CompressionOptions const&, char const*, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, rocksdb::Slice const&)':
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:738: undefined reference to `ZSTD_compressBound'
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:742: undefined reference to `ZSTD_createCCtx'
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:745: undefined reference to `ZSTD_compress_usingDict'
/home/aleksej/projects/gastronomica/rocksdb/./util/compression.h:746: undefined reference to `ZSTD_freeCCtx'
collect2: error: ld returned 1 exit status
```

Rocksdb version is 5.6.0. 
