### PR TITLE
Fixup Options.Destroy with MergeOperator

### DIFF
--- a/merge_operator.go
+++ b/merge_operator.go
@@ -48,21 +48,24 @@ type MergeOperator interface {
 }
 
 // NewNativeMergeOperator creates a MergeOperator object.
-func NewNativeMergeOperator(c *C.rocksdb_mergeoperator_t) MergeOperator {
-	return nativeMergeOperator{c}
+func NewNativeMergeOperator(c *C.rocksdb_mergeoperator_t) NativeMergeOperator {
+	return NativeMergeOperator{c}
 }
 
-type nativeMergeOperator struct {
+type NativeMergeOperator struct {
 	c *C.rocksdb_mergeoperator_t
 }
 
-func (mo nativeMergeOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
+func (mo NativeMergeOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
 	return nil, false
 }
-func (mo nativeMergeOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) {
+func (mo NativeMergeOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) {
 	return nil, false
 }
-func (mo nativeMergeOperator) Name() string { return "" }
+func (mo NativeMergeOperator) Name() string { return "" }
+func (mo NativeMergeOperator) Destroy() {
+	C.rocksdb_mergeoperator_destroy(mo.c)
+}
 
 // Hold references to merge operators.
 var mergeOperators []MergeOperator

--- a/options.go
+++ b/options.go
@@ -112,7 +112,7 @@ func (opts *Options) SetComparator(value Comparator) {
 // if a merge operations are used.
 // Default: nil
 func (opts *Options) SetMergeOperator(value MergeOperator) {
-	if nmo, ok := value.(nativeMergeOperator); ok {
+	if nmo, ok := value.(NativeMergeOperator); ok {
 		opts.cmo = nmo.c
 	} else {
 		idx := registerMergeOperator(value)
@@ -915,9 +915,6 @@ func (opts *Options) Destroy() {
 	C.rocksdb_options_destroy(opts.c)
 	if opts.ccmp != nil {
 		C.rocksdb_comparator_destroy(opts.ccmp)
-	}
-	if opts.cmo != nil {
-		C.rocksdb_mergeoperator_destroy(opts.cmo)
 	}
 	if opts.cst != nil {
 		C.rocksdb_slicetransform_destroy(opts.cst)


### PR DESCRIPTION
I have removed destroying of merge operator in Options.Destroy [because of this](https://github.com/facebook/rocksdb/issues/343).  And i think that NewNativeMergeOperator should return public struct NativeMergeOperator because there is a new public Destroy method on it now

fixes #51 