### PR TITLE
Add GetBytes equivalent for CF access

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -125,6 +125,16 @@ func (b *BackupEngine) GetInfo() *BackupEngineInfo {
 	}
 }
 
+func (b *BackupEngine) PurgeOldBackups(keepCount int) error {
+	var cErr *C.char
+	C.rocksdb_backup_engine_purge_old_backups(b.c, C.uint32_t(keepCount), &cErr)
+	if cErr != nil {
+		defer C.free(unsafe.Pointer(cErr))
+		return errors.New(C.GoString(cErr))
+	}
+	return nil
+}
+
 // RestoreDBFromLatestBackup restores the latest backup to dbDir. walDir
 // is where the write ahead logs are restored to and usually the same as dbDir.
 func (b *BackupEngine) RestoreDBFromLatestBackup(dbDir, walDir string, ro *RestoreOptions) error {

--- a/cf_test.go
+++ b/cf_test.go
@@ -81,10 +81,9 @@ func TestColumnFamilyBatchPutGet(t *testing.T) {
 	defer b0.Destroy()
 	b0.PutCF(cfh[0], givenKey0, givenVal0)
 	ensure.Nil(t, db.Write(wo, b0))
-	actualVal0, err := db.GetCF(ro, cfh[0], givenKey0)
-	defer actualVal0.Free()
+	actualVal0, err := db.GetBytesCF(ro, cfh[0], givenKey0)
 	ensure.Nil(t, err)
-	ensure.DeepEqual(t, actualVal0.Data(), givenVal0)
+	ensure.DeepEqual(t, actualVal0, givenVal0)
 
 	b1 := NewWriteBatch()
 	defer b1.Destroy()

--- a/db_test.go
+++ b/db_test.go
@@ -7,6 +7,11 @@ import (
 	"github.com/facebookgo/ensure"
 )
 
+func TestVersion(t *testing.T) {
+	ver := RocksDBVersion()
+	ensure.NotNil(t, ver)
+}
+
 func TestOpenDb(t *testing.T) {
 	db := newTestDB(t, "TestOpenDb", nil)
 	defer db.Close()

--- a/dynflag.go
+++ b/dynflag.go
@@ -1,4 +1,4 @@
 package gorocksdb
 
-// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy
+// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lsnappy
 import "C"

--- a/dynflag.go
+++ b/dynflag.go
@@ -1,4 +1,4 @@
 package gorocksdb
 
-// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lsnappy
+// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lsnappy -lrt
 import "C"

--- a/dynflag.go
+++ b/dynflag.go
@@ -1,4 +1,13 @@
 package gorocksdb
 
-// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lsnappy -lrt
+/*
+On Linux, we build Rocks manually and statically link in Snappy
+but our ancient GLIBC requires linking to librt
+On OSX, we use Homebrew's pre-built RockDB static binary
+but need to dynlink to Snappy
+*/
+
+// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm
+// #cgo linux LDFLAGS: -lrt
+// #cgo darwin LDFLAGS: -lsnappy
 import "C"

--- a/gorocksdb.c
+++ b/gorocksdb.c
@@ -3,6 +3,12 @@
 
 /* Base */
 
+// this has to be the stupidest way of doing this but my C skills
+// are vanishingly small
+int rocksdb_version() {
+  return ROCKSDB_MAJOR<<16 | ROCKSDB_MINOR << 8 | ROCKSDB_PATCH;
+}
+
 void gorocksdb_destruct_handler(void* state) { }
 
 /* Comparator */

--- a/gorocksdb.h
+++ b/gorocksdb.h
@@ -1,8 +1,9 @@
 #include <stdlib.h>
 #include "rocksdb/c.h"
+#include "rocksdb/version.h"
 
-// This API provides convenient C wrapper functions for rocksdb client.
 
+extern int rocksdb_version();
 /* Base */
 
 extern void gorocksdb_destruct_handler(void* state);

--- a/util.go
+++ b/util.go
@@ -59,9 +59,10 @@ func cByteSlice(b []byte) *C.char {
 }
 
 // stringToChar returns *C.char from string.
+// The C string is allocated in the C heap using malloc. It is the
+// caller's responsibility to arrange for it to be freed.
 func stringToChar(s string) *C.char {
-	ptrStr := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	return (*C.char)(unsafe.Pointer(ptrStr.Data))
+	return C.CString(s)
 }
 
 // charSlice converts a C array of *char to a []*C.char.

--- a/util.go
+++ b/util.go
@@ -1,10 +1,17 @@
 package gorocksdb
 
+// #include "gorocksdb.h"
 import "C"
 import (
+	"fmt"
 	"reflect"
 	"unsafe"
 )
+
+func RocksDBVersion() string {
+	ver := C.rocksdb_version()
+	return fmt.Sprintf("%d.%d.%d", ver>>16, (ver&0xFFFF)>>8, ver&0xFF)
+}
 
 // btoi converts a bool value to int.
 func btoi(b bool) int {


### PR DESCRIPTION
Get has GetBytes but GetCF doesn't have an equivalent so I added it.  This API is easier to deal with than manually copying data and releasing *Slices.