### PR TITLE
Make go callback registry threadsafe

### DIFF
--- a/compaction_filter.go
+++ b/compaction_filter.go
@@ -40,11 +40,10 @@ func (c nativeCompactionFilter) Filter(level int, key, val []byte) (remove bool,
 func (c nativeCompactionFilter) Name() string { return "" }
 
 // Hold references to compaction filters.
-var compactionFilters []CompactionFilter
+var compactionFilters = NewCOWList()
 
 func registerCompactionFilter(filter CompactionFilter) int {
-	compactionFilters = append(compactionFilters, filter)
-	return len(compactionFilters) - 1
+	return compactionFilters.Append(filter)
 }
 
 //export gorocksdb_compactionfilter_filter
@@ -52,7 +51,7 @@ func gorocksdb_compactionfilter_filter(idx int, cLevel C.int, cKey *C.char, cKey
 	key := charToByte(cKey, cKeyLen)
 	val := charToByte(cVal, cValLen)
 
-	remove, newVal := compactionFilters[idx].Filter(int(cLevel), key, val)
+	remove, newVal := compactionFilters.Get(idx).(CompactionFilter).Filter(int(cLevel), key, val)
 	if remove {
 		return C.int(1)
 	} else if newVal != nil {
@@ -65,5 +64,5 @@ func gorocksdb_compactionfilter_filter(idx int, cLevel C.int, cKey *C.char, cKey
 
 //export gorocksdb_compactionfilter_name
 func gorocksdb_compactionfilter_name(idx int) *C.char {
-	return stringToChar(compactionFilters[idx].Name())
+	return stringToChar(compactionFilters.Get(idx).(CompactionFilter).Name())
 }

--- a/comparator.go
+++ b/comparator.go
@@ -29,21 +29,20 @@ func (c nativeComparator) Compare(a, b []byte) int { return 0 }
 func (c nativeComparator) Name() string            { return "" }
 
 // Hold references to comperators.
-var comperators []Comparator
+var comperators = NewCOWList()
 
 func registerComperator(cmp Comparator) int {
-	comperators = append(comperators, cmp)
-	return len(comperators) - 1
+	return comperators.Append(cmp)
 }
 
 //export gorocksdb_comparator_compare
 func gorocksdb_comparator_compare(idx int, cKeyA *C.char, cKeyALen C.size_t, cKeyB *C.char, cKeyBLen C.size_t) C.int {
 	keyA := charToByte(cKeyA, cKeyALen)
 	keyB := charToByte(cKeyB, cKeyBLen)
-	return C.int(comperators[idx].Compare(keyA, keyB))
+	return C.int(comperators.Get(idx).(Comparator).Compare(keyA, keyB))
 }
 
 //export gorocksdb_comparator_name
 func gorocksdb_comparator_name(idx int) *C.char {
-	return stringToChar(comperators[idx].Name())
+	return stringToChar(comperators.Get(idx).(Comparator).Name())
 }

--- a/cow.go
+++ b/cow.go
@@ -1,0 +1,42 @@
+package gorocksdb
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// COWList implements a copy-on-write list. It is intended to be used by go
+// callback registry for CGO, which is read-heavy with occasional writes.
+// Reads do not block; Writes do not block reads (or vice versa), but only
+// one write can occur at once;
+type COWList struct {
+	v  *atomic.Value
+	mu *sync.Mutex
+}
+
+// NewCOWList creates a new COWList.
+func NewCOWList() *COWList {
+	var list []interface{}
+	v := &atomic.Value{}
+	v.Store(list)
+	return &COWList{v: v, mu: new(sync.Mutex)}
+}
+
+// Append appends an item to the COWList and returns the index for that item.
+func (c *COWList) Append(i interface{}) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	list := c.v.Load().([]interface{})
+	newLen := len(list) + 1
+	newList := make([]interface{}, newLen)
+	copy(newList, list)
+	newList[newLen-1] = i
+	c.v.Store(newList)
+	return newLen - 1
+}
+
+// Get gets the item at index.
+func (c *COWList) Get(index int) interface{} {
+	list := c.v.Load().([]interface{})
+	return list[index]
+}

--- a/cow_test.go
+++ b/cow_test.go
@@ -1,0 +1,36 @@
+package gorocksdb
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/facebookgo/ensure"
+)
+
+func TestCOWList(t *testing.T) {
+	cl := NewCOWList()
+	cl.Append("hello")
+	cl.Append("world")
+	cl.Append("!")
+	ensure.DeepEqual(t, cl.Get(0), "hello")
+	ensure.DeepEqual(t, cl.Get(1), "world")
+	ensure.DeepEqual(t, cl.Get(2), "!")
+}
+
+func TestCOWListMT(t *testing.T) {
+	cl := NewCOWList()
+	expectedRes := make([]int, 3)
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(v int) {
+			defer wg.Done()
+			index := cl.Append(v)
+			expectedRes[index] = v
+		}(i)
+	}
+	wg.Wait()
+	for i, v := range expectedRes {
+		ensure.DeepEqual(t, cl.Get(i), v)
+	}
+}

--- a/cow_test.go
+++ b/cow_test.go
@@ -1,6 +1,7 @@
 package gorocksdb
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -32,5 +33,16 @@ func TestCOWListMT(t *testing.T) {
 	wg.Wait()
 	for i, v := range expectedRes {
 		ensure.DeepEqual(t, cl.Get(i), v)
+	}
+}
+
+func BenchmarkCOWList_Get(b *testing.B) {
+	cl := NewCOWList()
+	for i := 0; i < 10; i++ {
+		cl.Append(fmt.Sprintf("helloworld%d", i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cl.Get(i % 10).(string)
 	}
 }

--- a/filter_policy.go
+++ b/filter_policy.go
@@ -50,11 +50,10 @@ func NewBloomFilter(bitsPerKey int) FilterPolicy {
 }
 
 // Hold references to filter policies.
-var filterPolicies []FilterPolicy
+var filterPolicies = NewCOWList()
 
 func registerFilterPolicy(fp FilterPolicy) int {
-	filterPolicies = append(filterPolicies, fp)
-	return len(filterPolicies) - 1
+	return filterPolicies.Append(fp)
 }
 
 //export gorocksdb_filterpolicy_create_filter
@@ -66,7 +65,7 @@ func gorocksdb_filterpolicy_create_filter(idx int, cKeys **C.char, cKeysLen *C.s
 		keys[i] = charToByte(rawKeys[i], len)
 	}
 
-	dst := filterPolicies[idx].CreateFilter(keys)
+	dst := filterPolicies.Get(idx).(FilterPolicy).CreateFilter(keys)
 	*cDstLen = C.size_t(len(dst))
 	return cByteSlice(dst)
 }
@@ -75,10 +74,10 @@ func gorocksdb_filterpolicy_create_filter(idx int, cKeys **C.char, cKeysLen *C.s
 func gorocksdb_filterpolicy_key_may_match(idx int, cKey *C.char, cKeyLen C.size_t, cFilter *C.char, cFilterLen C.size_t) C.uchar {
 	key := charToByte(cKey, cKeyLen)
 	filter := charToByte(cFilter, cFilterLen)
-	return boolToChar(filterPolicies[idx].KeyMayMatch(key, filter))
+	return boolToChar(filterPolicies.Get(idx).(FilterPolicy).KeyMayMatch(key, filter))
 }
 
 //export gorocksdb_filterpolicy_name
 func gorocksdb_filterpolicy_name(idx int) *C.char {
-	return stringToChar(filterPolicies[idx].Name())
+	return stringToChar(filterPolicies.Get(idx).(FilterPolicy).Name())
 }

--- a/merge_operator_test.go
+++ b/merge_operator_test.go
@@ -29,8 +29,8 @@ func TestMergeOperator(t *testing.T) {
 	wo := NewDefaultWriteOptions()
 	ensure.Nil(t, db.Put(wo, givenKey, givenVal1))
 	ensure.Nil(t, db.Merge(wo, givenKey, givenVal2))
-    
-    // trigger a compaction to ensure that a merge is performed
+
+	// trigger a compaction to ensure that a merge is performed
 	db.CompactRange(Range{nil, nil})
 
 	ro := NewDefaultReadOptions()


### PR DESCRIPTION
Currently the go callbacks for CGO are registered without synchronization. This PR changes the registries to use a copy-on-write list so that it's threadsafe, and doesn't incur much overhead in read path.

The issue was detected by go race detector, when a rocksb was already running and another goroutine tries to register a new comparator (e.g. create a SST filter writer, or open a separate rocksdb instance).