### PR TITLE
updated options

### DIFF
--- a/options.go
+++ b/options.go
@@ -511,6 +511,24 @@ func (opts *Options) SetMaxCompactionBytes(value uint64) {
 	C.rocksdb_options_set_max_compaction_bytes(opts.c, C.uint64_t(value))
 }
 
+// SetSoftPendingCompactionBytesLimit sets the threshold at which
+// all writes will be slowed down to at least delayed_write_rate if estimated
+// bytes needed to be compaction exceed this threshold.
+//
+// Default: 64GB
+func (opts *Options) SetSoftPendingCompactionBytesLimit(value uint64) {
+	C.rocksdb_options_set_soft_pending_compaction_bytes_limit(opts.c, C.size_t(value))
+}
+
+// SetHardPendingCompactionBytesLimit sets the bytes threshold at which
+// all writes are stopped if estimated bytes needed to be compaction exceed
+// this threshold.
+//
+// Default: 256GB
+func (opts *Options) SetHardPendingCompactionBytesLimit(value uint64) {
+	C.rocksdb_options_set_hard_pending_compaction_bytes_limit(opts.c, C.size_t(value))
+}
+
 // SetMaxBytesForLevelMultiplierAdditional sets different max-size multipliers
 // for different levels.
 //
@@ -746,7 +764,7 @@ func (opts *Options) SetAllowMmapReads(value bool) {
 }
 
 // SetAllowMmapWrites enable/disable mmap writes for writing sst tables.
-// Default: true
+// Default: false
 func (opts *Options) SetAllowMmapWrites(value bool) {
 	C.rocksdb_options_set_allow_mmap_writes(opts.c, boolToChar(value))
 }
@@ -791,6 +809,20 @@ func (opts *Options) SetStatsDumpPeriodSec(value uint) {
 // Default: true
 func (opts *Options) SetAdviseRandomOnOpen(value bool) {
 	C.rocksdb_options_set_advise_random_on_open(opts.c, boolToChar(value))
+}
+
+// SetDbWriteBufferSize sets the amount of data to build up
+// in memtables across all column families before writing to disk.
+//
+// This is distinct from write_buffer_size, which enforces a limit
+// for a single memtable.
+//
+// This feature is disabled by default. Specify a non-zero value
+// to enable it.
+//
+// Default: 0 (disabled)
+func (opts *Options) SetDbWriteBufferSize(value int) {
+	C.rocksdb_options_set_db_write_buffer_size(opts.c, C.size_t(value))
 }
 
 // SetAccessHintOnCompactionStart specifies the file access pattern
@@ -876,6 +908,21 @@ func (opts *Options) SetInplaceUpdateSupport(value bool) {
 // Default: 10000, if inplace_update_support = true, else 0.
 func (opts *Options) SetInplaceUpdateNumLocks(value int) {
 	C.rocksdb_options_set_inplace_update_num_locks(opts.c, C.size_t(value))
+}
+
+// SetMemtableHugePageSize sets the page size for huge page for
+// arena used by the memtable.
+// If <=0, it won't allocate from huge page but from malloc.
+// Users are responsible to reserve huge pages for it to be allocated. For
+// example:
+//      sysctl -w vm.nr_hugepages=20
+// See linux doc Documentation/vm/hugetlbpage.txt
+// If there isn't enough free huge page available, it will fall back to
+// malloc.
+//
+// Dynamically changeable through SetOptions() API
+func (opts *Options) SetMemtableHugePageSize(value int) {
+	C.rocksdb_options_set_memtable_huge_page_size(opts.c, C.size_t(value))
 }
 
 // SetBloomLocality sets the bloom locality.

--- a/options_block_based_table.go
+++ b/options_block_based_table.go
@@ -4,6 +4,20 @@ package gorocksdb
 // #include "gorocksdb.h"
 import "C"
 
+// IndexType specifies the index type that will be used for this table.
+type IndexType uint
+
+const (
+	// A space efficient index block that is optimized for
+	// binary-search-based index.
+	KBinarySearchIndexType = 0
+	// The hash index, if enabled, will do the hash lookup when
+	// `Options.prefix_extractor` is provided.
+	KHashSearchIndexType = 1
+	// A two-level index implementation. Both levels are binary search indexes.
+	KTwoLevelIndexSearchIndexType = 2
+)
+
 // BlockBasedTableOptions represents block-based table options.
 type BlockBasedTableOptions struct {
 	c *C.rocksdb_block_based_table_options_t
@@ -32,6 +46,23 @@ func (opts *BlockBasedTableOptions) Destroy() {
 	opts.c = nil
 	opts.cache = nil
 	opts.compCache = nil
+}
+
+// SetCacheIndexAndFilterBlocks is indicating if we'd put index/filter blocks to the block cache.
+// If not specified, each "table reader" object will pre-load index/filter
+// block during table initialization.
+// Default: false
+func (opts *BlockBasedTableOptions) SetCacheIndexAndFilterBlocks(value bool) {
+	C.rocksdb_block_based_options_set_cache_index_and_filter_blocks(opts.c, boolToChar(value))
+}
+
+// SetPinL0FilterAndIndexBlocksInCache sets cache_index_and_filter_blocks.
+// If is true and the below is true (hash_index_allow_collision), then
+// filter and index blocks are stored in the cache, but a reference is
+// held in the "table reader" object so the blocks are pinned and only
+// evicted from cache when the table reader is freed.
+func (opts *BlockBasedTableOptions) SetPinL0FilterAndIndexBlocksInCache(value bool) {
+	C.rocksdb_block_based_options_set_pin_l0_filter_and_index_blocks_in_cache(opts.c, boolToChar(value))
 }
 
 // SetBlockSize sets the approximate size of user data packed per block.
@@ -108,4 +139,20 @@ func (opts *BlockBasedTableOptions) SetBlockCacheCompressed(cache *Cache) {
 // Default: true
 func (opts *BlockBasedTableOptions) SetWholeKeyFiltering(value bool) {
 	C.rocksdb_block_based_options_set_whole_key_filtering(opts.c, boolToChar(value))
+}
+
+// SetIndexType sets the index type used for this table.
+// kBinarySearch:
+// A space efficient index block that is optimized for
+// binary-search-based index.
+//
+// kHashSearch:
+// The hash index, if enabled, will do the hash lookup when
+// `Options.prefix_extractor` is provided.
+//
+// kTwoLevelIndexSearch:
+// A two-level index implementation. Both levels are binary search indexes.
+// Default: kBinarySearch
+func (opts *BlockBasedTableOptions) SetIndexType(value IndexType) {
+	C.rocksdb_block_based_options_set_index_type(opts.c, C.int(value))
 }


### PR DESCRIPTION
updated options. allow_mmap_writes meanwhile defaults to false.
Tested on 5.8.fb and 5.9.fb