### PR TITLE
Adhere to cgo pointer passing rules in GetApproximateSizes.

### DIFF
--- a/db.go
+++ b/db.go
@@ -449,9 +449,15 @@ func (db *DB) GetApproximateSizes(ranges []Range) []uint64 {
 	cStartLens := make([]C.size_t, len(ranges))
 	cLimitLens := make([]C.size_t, len(ranges))
 	for i, r := range ranges {
-		cStarts[i] = byteToChar(r.Start)
+		start := C.CBytes(r.Start)
+		defer C.free(start)
+
+		limit := C.CBytes(r.Limit)
+		defer C.free(limit)
+
+		cStarts[i] = (*C.char)(start)
 		cStartLens[i] = C.size_t(len(r.Start))
-		cLimits[i] = byteToChar(r.Limit)
+		cLimits[i] = (*C.char)(limit)
 		cLimitLens[i] = C.size_t(len(r.Limit))
 	}
 
@@ -483,9 +489,15 @@ func (db *DB) GetApproximateSizesCF(cf *ColumnFamilyHandle, ranges []Range) []ui
 	cStartLens := make([]C.size_t, len(ranges))
 	cLimitLens := make([]C.size_t, len(ranges))
 	for i, r := range ranges {
-		cStarts[i] = byteToChar(r.Start)
+		start := C.CBytes(r.Start)
+		defer C.free(start)
+
+		limit := C.CBytes(r.Limit)
+		defer C.free(limit)
+
+		cStarts[i] = (*C.char)(start)
 		cStartLens[i] = C.size_t(len(r.Start))
-		cLimits[i] = byteToChar(r.Limit)
+		cLimits[i] = (*C.char)(limit)
 		cLimitLens[i] = C.size_t(len(r.Limit))
 	}
 

--- a/gorocksdb.c
+++ b/gorocksdb.c
@@ -1,5 +1,15 @@
+#include <stdlib.h>
+#include <string.h>
 #include "gorocksdb.h"
 #include "_cgo_export.h"
+
+void* copy_bytes(void* data, size_t len) {
+    char* p = malloc(len);
+    if (p != 0) {
+        memmove(p, data, len);
+    }
+    return p;
+}
 
 /* Base */
 

--- a/gorocksdb.h
+++ b/gorocksdb.h
@@ -3,6 +3,8 @@
 
 // This API provides convenient C wrapper functions for rocksdb client.
 
+extern void* copy_bytes(void* data, size_t len);
+
 /* Base */
 
 extern void gorocksdb_destruct_handler(void* state);


### PR DESCRIPTION
Go 1.6 introduced stricter rules for passing pointers between Go and C, and these changes cause the functions GetApproximateSizes and GetApproximateSizesCF to panic.  Here are the error message and stack trace:

panic: runtime error: cgo argument has Go pointer to Go pointer

```
panic(0x5470e0, 0xc4200ab5a0)
        /usr/local/go/src/runtime/panic.go:489 +0x2cf
github.com/skyportsystems/gorocksdb.(*DB).GetApproximateSizesCF.func1(0xc42000e2c0, 0x1, 0x1, 0xc42000e2c8, 0x1, 0x1, 0x1fdb9e0, 0x1fe2480, 0x1, 0xc42000e2c0, ...)
        /tree/src/github.com/skyportsystems/gorocksdb/db.go:490 +0x156
github.com/skyportsystems/gorocksdb.(*DB).GetApproximateSizesCF(0xc42000ce40, 0xc42000e0d0, 0xc420037c90, 0x1, 0x1, 0x9, 0x0, 0x0)
        /tree/src/github.com/skyportsystems/gorocksdb/db.go:500 +0x48b
```

The Go 1.6 release notes describe the change briefly: https://golang.org/doc/go1.6#cgo

More details are here:
* https://golang.org/cmd/cgo/#hdr-Passing_pointers
* https://github.com/golang/proposal/blob/master/design/12416-cgo-pointers.md
