### PR TITLE
extend the write batch parser

### DIFF
--- a/write_batch.go
+++ b/write_batch.go
@@ -132,7 +132,6 @@ type WriteBatchRecord struct {
 	CF    int
 	Key   []byte
 	Value []byte
-	Blob  []byte
 	Type  WriteBatchRecordType
 }
 
@@ -153,7 +152,6 @@ func (iter *WriteBatchIterator) Next() bool {
 	iter.record.CF = 0
 	iter.record.Key = nil
 	iter.record.Value = nil
-	iter.record.Blob = nil
 
 	// parse the record type
 	iter.record.Type = iter.decodeRecType()
@@ -192,7 +190,7 @@ func (iter *WriteBatchIterator) Next() bool {
 			iter.record.Value = iter.decodeSlice()
 		}
 	case WriteBatchLogDataRecord:
-		iter.record.Blob = iter.decodeSlice()
+		iter.record.Value = iter.decodeSlice()
 	case
 		WriteBatchNoopRecord,
 		WriteBatchBeginPrepareXIDRecord,
@@ -201,7 +199,7 @@ func (iter *WriteBatchIterator) Next() bool {
 		WriteBatchEndPrepareXIDRecord,
 		WriteBatchCommitXIDRecord,
 		WriteBatchRollbackXIDRecord:
-		iter.record.Blob = iter.decodeSlice()
+		iter.record.Value = iter.decodeSlice()
 	default:
 		iter.err = errors.New("unsupported wal record type")
 	}

--- a/write_batch_test.go
+++ b/write_batch_test.go
@@ -61,13 +61,13 @@ func TestWriteBatchIterator(t *testing.T) {
 	iter := wb.NewIterator()
 	ensure.True(t, iter.Next())
 	record := iter.Record()
-	ensure.DeepEqual(t, record.Type, WriteBatchRecordTypeValue)
+	ensure.DeepEqual(t, record.Type, WriteBatchValueRecord)
 	ensure.DeepEqual(t, record.Key, givenKey1)
 	ensure.DeepEqual(t, record.Value, givenVal1)
 
 	ensure.True(t, iter.Next())
 	record = iter.Record()
-	ensure.DeepEqual(t, record.Type, WriteBatchRecordTypeDeletion)
+	ensure.DeepEqual(t, record.Type, WriteBatchDeletionRecord)
 	ensure.DeepEqual(t, record.Key, givenKey2)
 
 	// there shouldn't be any left


### PR DESCRIPTION
I extended the write batch parser to support record types described in rocksdb headers.
Mostly useful for log parsing which gorocksdb does not support yet :)
But, let's start with something.