### PR TITLE
Test using cgocheck=2 and fix compaction_filter test for that

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - go get -t ./...
 
 script:
-  - go test -v ./
+  - GODEBUG=cgocheck=2 go test -v ./
 
 notifications:
   email:

--- a/compaction_filter_test.go
+++ b/compaction_filter_test.go
@@ -11,9 +11,12 @@ func TestCompactionFilter(t *testing.T) {
 	var (
 		changeKey    = []byte("change")
 		changeValOld = []byte("old")
-		changeValNew = []byte("new")
+		changeValNew = cBackedBytes([]byte("new"))
 		deleteKey    = []byte("delete")
 	)
+
+	defer freeCBackedBytes(changeValNew)
+
 	db := newTestDB(t, "TestCompactionFilter", func(opts *Options) {
 		opts.SetCompactionFilter(&mockCompactionFilter{
 			filter: func(level int, key, val []byte) (remove bool, newVal []byte) {

--- a/util.go
+++ b/util.go
@@ -1,5 +1,6 @@
 package gorocksdb
 
+// #include <stdlib.h>
 import "C"
 import (
 	"reflect"
@@ -28,6 +29,19 @@ func charToByte(data *C.char, len C.size_t) []byte {
 	sH := (*reflect.SliceHeader)(unsafe.Pointer(&value))
 	sH.Cap, sH.Len, sH.Data = int(len), int(len), uintptr(unsafe.Pointer(data))
 	return value
+}
+
+// cBackedBytes returs a copy of the same byte slice which is backed by
+// malloced memory. This should be freed using freeCBackedBytes.
+func cBackedBytes(data []byte) []byte {
+	return charToByte(cByteSlice(data), C.size_t(len(data)))
+}
+
+// freeCBackedBytes frees a byte slice created by cBackedBytes
+func freeCBackedBytes(data []byte) {
+	sH := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+	C.free(unsafe.Pointer(sH.Data))
+
 }
 
 // byteToChar returns *C.char from byte slice.


### PR DESCRIPTION
Like I mentioned in #120 you can check with cgocheck=2 to find violations of
CGO pointer rules. This enables that on Travis and fixes the test where it was
failing because of it.