### PR TITLE
add WAL iterator

### DIFF
--- a/db.go
+++ b/db.go
@@ -377,6 +377,16 @@ func (db *DB) NewIteratorCF(opts *ReadOptions, cf *ColumnFamilyHandle) *Iterator
 	return NewNativeIterator(unsafe.Pointer(cIter))
 }
 
+func (db *DB) GetUpdatesSince (seq_number uint64) *WalIterator {
+	var cErr *C.char
+	cIter := C.rocksdb_get_updates_since(db.c, C.uint64_t(seq_number), nil, &cErr)
+	return NewNativeWalIterator(unsafe.Pointer(cIter))
+}
+
+func (db *DB) GetLatestSequenceNumber () uint64 {
+	return uint64(C.rocksdb_get_latest_sequence_number(db.c))
+}
+
 // NewSnapshot creates a new snapshot of the database.
 func (db *DB) NewSnapshot() *Snapshot {
 	cSnap := C.rocksdb_create_snapshot(db.c)

--- a/db_test.go
+++ b/db_test.go
@@ -97,8 +97,8 @@ func newTestDB(t *testing.T, name string, applyOpts func(opts *Options)) *DB {
 
 	opts := NewDefaultOptions()
 	// test the ratelimiter
-	rateLimiter := NewRateLimiter(1024, 100*1000, 10)
-	opts.SetRateLimiter(rateLimiter)
+	//rateLimiter := NewRateLimiter(1024, 100*1000, 10)
+	//opts.SetRateLimiter(rateLimiter)
 	opts.SetCreateIfMissing(true)
 	if applyOpts != nil {
 		applyOpts(opts)

--- a/wal_iterator.go
+++ b/wal_iterator.go
@@ -1,0 +1,44 @@
+package gorocksdb
+// #include <stdlib.h>
+// #include "rocksdb/c.h"
+import "C"
+import (
+	"unsafe"
+)
+
+type WalIterator struct {
+	c *C.rocksdb_wal_iterator_t
+}
+
+func NewNativeWalIterator(c unsafe.Pointer) *WalIterator {
+	return &WalIterator{(*C.rocksdb_wal_iterator_t)(c)}
+}
+
+func (iter *WalIterator) Valid() bool {
+	return C.rocksdb_wal_iter_valid(iter.c) != 0
+}
+
+func (iter *WalIterator) Next() {
+	C.rocksdb_wal_iter_next(iter.c)
+}
+
+func (iter *WalIterator) Status() string {
+	var cErr  *C.char
+	C.rocksdb_wal_iter_status(iter.c, &cErr)
+	if cErr != nil {
+		defer C.free(unsafe.Pointer(cErr))
+		return C.GoString(cErr)
+	}
+	return "unknown"
+}
+
+func (iter *WalIterator) Destroy() {
+	C.rocksdb_wal_iter_destroy(iter.c)
+	iter.c = nil
+}
+
+func (iter *WalIterator) Batch() (*WriteBatch, uint64) {
+	var cSeq C.uint64_t
+	cB := C.rocksdb_wal_iter_get_batch(iter.c, &cSeq)
+	return NewNativeWriteBatch(cB), uint64(cSeq)
+}

--- a/wal_iterator_test.go
+++ b/wal_iterator_test.go
@@ -1,0 +1,119 @@
+package gorocksdb
+
+import (
+	"testing"
+
+	"github.com/facebookgo/ensure"
+	"fmt"
+	"time"
+	"math/rand"
+
+	"io/ioutil"
+)
+
+func SlowWriter (db *DB, count int, name string, cf *ColumnFamilyHandle) {
+	wo := NewDefaultWriteOptions()
+	for i:=0; i<count; i++ {
+		key := fmt.Sprintf("%s%d", name, i)
+		err := db.PutCF(wo, cf, []byte(key), []byte("value"))
+		if err!=nil {
+			fmt.Println("> WRITE ERROR", err.Error())
+		} else {
+			//fmt.Printf("> %d %s\n", i, key)
+		}
+		time.Sleep(time.Duration(rand.Int()%10)) // 0..9.99ms
+		if (i+1)%100 == 0 {
+			fmt.Printf("generated %d records\n", i+1)
+			time.Sleep(time.Second)
+		}
+	}
+	fmt.Println(">i think i am done", name)
+}
+
+func TestWalIterator(t *testing.T) {
+	dir, err := ioutil.TempDir("", "gorocksdb-wal-cf")
+	fmt.Println("DIR", dir)
+	if err!=nil {
+		t.Fail()
+		t.Log(err.Error())
+		return
+	}
+	var cf_names = []string{"default", "one", "two", "three"}
+
+	opts := NewDefaultOptions()
+	opts.SetCreateIfMissing(true)
+	opts.SetCreateIfMissingColumnFamilies(true)
+	opts.SetWALTtlSeconds(1)
+
+	var cfopts = []*Options{opts, opts, opts, opts}
+
+	db, handles, err := OpenDbColumnFamilies(opts, dir, cf_names, cfopts)
+	if err!=nil {
+		t.Fail()
+		t.Log(err.Error())
+		return
+	}
+	//db := newTestDB(t, "TestWalIterator", nil)
+
+	_ = handles
+
+	//wo := NewDefaultWriteOptions()
+	//db.Put(wo, []byte("start_key"), []byte("value"))
+	count := 1<<10
+	go SlowWriter(db, count>>2, "one", handles[1])
+	go SlowWriter(db, count>>2, "two", handles[2])
+	go SlowWriter(db, count>>2, "three", handles[3])
+	go SlowWriter(db, count>>2, "default", handles[0])
+	var i int
+	var seq uint64
+	var iter *WalIterator
+	cfCount := [4]int{0,0,0,0}
+	for i<count {
+		for db.GetLatestSequenceNumber()<=seq {
+			fmt.Printf("still at %d\n", db.GetLatestSequenceNumber())
+			time.Sleep(time.Millisecond*100)
+		}
+		if iter==nil {
+			iter = db.GetUpdatesSince(seq+1)
+			fmt.Printf("reset to %d, status %s\n", seq, iter.Status())
+			time.Sleep(time.Millisecond)
+		} else {
+			iter.Next()
+		}
+		if !iter.Valid() {
+			fmt.Printf("no longer valid: %s\n", iter.Status())
+			time.Sleep(time.Millisecond)
+			iter.Destroy()
+			iter = nil
+			continue
+		}
+		var batch *WriteBatch
+		batch, newSeq := iter.Batch()
+		if newSeq>seq {
+			seq = newSeq
+			//fmt.Printf("< %d ", seq)
+			for bi := batch.NewIterator(); bi.Next(); {
+				rec := bi.Record()
+				fmt.Printf("%d '%s' (%d)\n", rec.CF, string(rec.Key), seq)
+				i++
+				cfCount[rec.CF]++
+			}
+		} else {
+			seq++ // :(
+		}
+		//fmt.Println()
+		batch.Destroy()
+	}
+	if iter!=nil {
+		iter.Destroy()
+	}
+	fmt.Println("<I THINK IM DONE")
+	ensure.DeepEqual(t, i, count)
+	ensure.DeepEqual(t, cfCount, [4]int{count>>2,count>>2,count>>2,count>>2,})
+
+	for i:=0; i<len(handles); i++ {
+		handles[i].Destroy()
+	}
+	db.Close()
+}
+


### PR DESCRIPTION
Hi @tecbot!

Since version 5.14, RocksDB has my WAL iterator C API patch.
https://github.com/facebook/rocksdb/commit/c9ace1d81bb06fa037cc3cf99716732a835b633f

Hence, the golang binding may now benefit from @olebedev's WAL iterator API patch.