### PR TITLE
statically link on Linux when the "static" build tag is provided

### DIFF
--- a/dynflag.go
+++ b/dynflag.go
@@ -1,3 +1,5 @@
+// +build !linux !static
+
 package gorocksdb
 
 // #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy

--- a/staticflag_linux.go
+++ b/staticflag_linux.go
@@ -1,0 +1,6 @@
+// +build static
+
+package gorocksdb
+
+// #cgo LDFLAGS: -l:librocksdb.a -l:libstdc++.a -l:libz.a -l:libbz2.a -l:libsnappy.a -lm
+import "C"


### PR DESCRIPTION
This sets the cgo LDFLAGS to statically link in librocksdb, libstdc++,
libz, libbz2, and libsnappy.  libm is still linked dynamically.