### PR TITLE
Add GetStatisticsString method to Options

### DIFF
--- a/options.go
+++ b/options.go
@@ -937,6 +937,13 @@ func (opts *Options) SetFIFOCompactionOptions(value *FIFOCompactionOptions) {
 	C.rocksdb_options_set_fifo_compaction_options(opts.c, value.c)
 }
 
+// GetStatisticsString returns the statistics as a string.
+func (opts *Options) GetStatisticsString() string {
+	sString := C.rocksdb_options_statistics_get_string(opts.c)
+	defer C.free(unsafe.Pointer(sString))
+	return C.GoString(sString)
+}
+
 // SetRateLimiter sets the rate limiter of the options.
 // Use to control write rate of flush and compaction. Flush has higher
 // priority than compaction. Rate limiting is disabled if nullptr.


### PR DESCRIPTION
This PR add a method GetStatisticsString that wraps the `rocksdb_options_statistics_get_string` function and returns the string representation of the statistics for the db if they have been enabled.