### PR TITLE
fix memory leak in deleting filterpolicy and mergeoperator value

### DIFF
--- a/gorocksdb.c
+++ b/gorocksdb.c
@@ -37,7 +37,9 @@ rocksdb_filterpolicy_t* gorocksdb_filterpolicy_create(uintptr_t idx) {
         (const char *(*)(void*))(gorocksdb_filterpolicy_name));
 }
 
-void gorocksdb_filterpolicy_delete_filter(void* state, const char* v, size_t s) { }
+void gorocksdb_filterpolicy_delete_filter(void* state, const char* v, size_t s) {
+    free((char*)v);
+}
 
 /* Merge Operator */
 
@@ -51,7 +53,9 @@ rocksdb_mergeoperator_t* gorocksdb_mergeoperator_create(uintptr_t idx) {
         (const char* (*)(void*))(gorocksdb_mergeoperator_name));
 }
 
-void gorocksdb_mergeoperator_delete_value(void* id, const char* v, size_t s) { }
+void gorocksdb_mergeoperator_delete_value(void* id, const char* v, size_t s) {
+    free((char*)v);
+}
 
 /* Slice Transform */
 


### PR DESCRIPTION
An empty implementation of function gorocksdb_filterpolicy_delete_filter and gorocksdb_mergeoperator_delete_value preventing default function free to be called. It may lead to memory leak.
See [https://github.com/facebook/rocksdb/blob/master/db/c.cc](rocksdb/blob/master/db/c.cc)