### PR TITLE
fix GetApproximateSizes

### DIFF
--- a/db.go
+++ b/db.go
@@ -543,11 +543,18 @@ func (db *DB) GetApproximateSizes(ranges []Range) []uint64 {
 	cStartLens := make([]C.size_t, len(ranges))
 	cLimitLens := make([]C.size_t, len(ranges))
 	for i, r := range ranges {
-		cStarts[i] = byteToChar(r.Start)
+		cStarts[i] = (*C.char)(C.CBytes(r.Start))
 		cStartLens[i] = C.size_t(len(r.Start))
-		cLimits[i] = byteToChar(r.Limit)
+		cLimits[i] = (*C.char)(C.CBytes(r.Limit))
 		cLimitLens[i] = C.size_t(len(r.Limit))
 	}
+
+	defer func() {
+		for i := range ranges {
+			C.free(unsafe.Pointer(cStarts[i]))
+			C.free(unsafe.Pointer(cLimits[i]))
+		}
+	}()
 
 	C.rocksdb_approximate_sizes(
 		db.c,
@@ -577,11 +584,18 @@ func (db *DB) GetApproximateSizesCF(cf *ColumnFamilyHandle, ranges []Range) []ui
 	cStartLens := make([]C.size_t, len(ranges))
 	cLimitLens := make([]C.size_t, len(ranges))
 	for i, r := range ranges {
-		cStarts[i] = byteToChar(r.Start)
+		cStarts[i] = (*C.char)(C.CBytes(r.Start))
 		cStartLens[i] = C.size_t(len(r.Start))
-		cLimits[i] = byteToChar(r.Limit)
+		cLimits[i] = (*C.char)(C.CBytes(r.Limit))
 		cLimitLens[i] = C.size_t(len(r.Limit))
 	}
+
+	defer func() {
+		for i := range ranges {
+			C.free(unsafe.Pointer(cStarts[i]))
+			C.free(unsafe.Pointer(cLimits[i]))
+		}
+	}()
 
 	C.rocksdb_approximate_sizes_cf(
 		db.c,

--- a/db_test.go
+++ b/db_test.go
@@ -172,3 +172,42 @@ func TestDBMultiGet(t *testing.T) {
 	ensure.DeepEqual(t, values[2].Data(), givenVal2)
 	ensure.DeepEqual(t, values[3].Data(), givenVal3)
 }
+
+func TestDBGetApproximateSizes(t *testing.T) {
+	db := newTestDB(t, "TestDBGetApproximateSizes", nil)
+	defer db.Close()
+
+	// no ranges
+	sizes := db.GetApproximateSizes(nil)
+	ensure.DeepEqual(t, len(sizes), 0)
+
+	// range will nil start and limit
+	sizes = db.GetApproximateSizes([]Range{{Start: nil, Limit: nil}})
+	ensure.DeepEqual(t, sizes, []uint64{0})
+
+	// valid range
+	sizes = db.GetApproximateSizes([]Range{{Start: []byte{0x00}, Limit: []byte{0xFF}}})
+	ensure.DeepEqual(t, sizes, []uint64{0})
+}
+
+func TestDBGetApproximateSizesCF(t *testing.T) {
+	db := newTestDB(t, "TestDBGetApproximateSizesCF", nil)
+	defer db.Close()
+
+	o := NewDefaultOptions()
+
+	cf, err := db.CreateColumnFamily(o, "other")
+	ensure.Nil(t, err)
+
+	// no ranges
+	sizes := db.GetApproximateSizesCF(cf, nil)
+	ensure.DeepEqual(t, len(sizes), 0)
+
+	// range will nil start and limit
+	sizes = db.GetApproximateSizesCF(cf, []Range{{Start: nil, Limit: nil}})
+	ensure.DeepEqual(t, sizes, []uint64{0})
+
+	// valid range
+	sizes = db.GetApproximateSizesCF(cf, []Range{{Start: []byte{0x00}, Limit: []byte{0xFF}}})
+	ensure.DeepEqual(t, sizes, []uint64{0})
+}


### PR DESCRIPTION
fixes https://github.com/tecbot/gorocksdb/issues/148

using go1.11.4 I was also getting the same error:
```
panic: runtime error: cgo argument has Go pointer to Go pointer [recovered]
panic: runtime error: cgo argument has Go pointer to Go pointer
```

I think the issue is that cgo can't convert the `[]*C.char` slice because it contains pointers to go memory. Need to convert the limits to C memory.