### PR TITLE
Correct default value for SetWriteBufferSize in comment

### DIFF
--- a/options.go
+++ b/options.go
@@ -333,7 +333,7 @@ func (opts *Options) OptimizeUniversalStyleCompaction(memtable_memory_budget uin
 // so you may wish to adjust this parameter to control memory usage.
 // Also, a larger write buffer will result in a longer recovery time
 // the next time the database is opened.
-// Default: 4MB
+// Default: 64MB
 func (opts *Options) SetWriteBufferSize(value int) {
 	C.rocksdb_options_set_write_buffer_size(opts.c, C.size_t(value))
 }


### PR DESCRIPTION
According to https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#column-family-write-buffer-size default for `SetWriteBufferSize` should be `64MB` and not `4MB`