### PR TITLE
Add bindings for lowering CPU and IO priority of thread pools

### DIFF
--- a/dynflag.go
+++ b/dynflag.go
@@ -1,4 +1,4 @@
 package gorocksdb
 
-// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy
+// #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -ldl
 import "C"

--- a/env.go
+++ b/env.go
@@ -33,6 +33,22 @@ func (env *Env) SetHighPriorityBackgroundThreads(n int) {
 	C.rocksdb_env_set_high_priority_background_threads(env.c, C.int(n))
 }
 
+func (env *Env) LowerThreadPoolIOPriority() {
+	C.rocksdb_env_lower_thread_pool_io_priority(env.c)
+}
+
+func (env *Env) LowerHighPriorityThreadPoolIOPriority() {
+	C.rocksdb_env_lower_high_priority_thread_pool_io_priority(env.c)
+}
+
+func (env *Env) LowerThreadPoolCPUPriority() {
+	C.rocksdb_env_lower_thread_pool_cpu_priority(env.c)
+}
+
+func (env *Env) LowerHighPriorityThreadPoolCPUPriority() {
+	C.rocksdb_env_lower_high_priority_thread_pool_cpu_priority(env.c)
+}
+
 // Destroy deallocates the Env object.
 func (env *Env) Destroy() {
 	C.rocksdb_env_destroy(env.c)


### PR DESCRIPTION
This adds support for the newly added functions here: https://github.com/facebook/rocksdb/commit/6451673f379319755ff238ffef18c674ce37bd0b

Keep in mind this is currently only on rocksdb master though, so you might want to hold of on merging.