### PR TITLE
Add prefix same as start to read options

### DIFF
--- a/options_read.go
+++ b/options_read.go
@@ -48,6 +48,17 @@ func (opts *ReadOptions) SetVerifyChecksums(value bool) {
 	C.rocksdb_readoptions_set_verify_checksums(opts.c, boolToChar(value))
 }
 
+// SetPrefixSameAsStart Enforce that the iterator only iterates over the same
+// prefix as the seek.
+// This option is effective only for prefix seeks, i.e. prefix_extractor is
+// non-null for the column family and total_order_seek is false.  Unlike
+// iterate_upper_bound, prefix_same_as_start only works within a prefix
+// but in both directions.
+// Default: false
+func (opts *ReadOptions) SetPrefixSameAsStart(value bool) {
+	C.rocksdb_readoptions_set_prefix_same_as_start(opts.c, boolToChar(value))
+}
+
 // SetFillCache specify whether the "data block"/"index block"/"filter block"
 // read for this iteration should be cached in memory?
 // Callers may wish to set this field to false for bulk scans.


### PR DESCRIPTION
This option was not exposed but is available in rocksdb/c.h (https://github.com/facebook/rocksdb/blob/master/include/rocksdb/c.h#L1234)

Setting to true ensures a prefix-seek iterator only iterates over values matching the prefix (https://github.com/facebook/rocksdb/wiki/Prefix-Seek-API-Changes#prefix-seek-api)