### PR TITLE
Add PutLogData support for WriteBatch object

### DIFF
--- a/write_batch.go
+++ b/write_batch.go
@@ -41,6 +41,12 @@ func (wb *WriteBatch) PutCF(cf *ColumnFamilyHandle, key, value []byte) {
 	C.rocksdb_writebatch_put_cf(wb.c, cf.c, cKey, C.size_t(len(key)), cValue, C.size_t(len(value)))
 }
 
+// Append a blob of arbitrary size to the records in this batch.
+func (wb *WriteBatch) PutLogData(blob []byte) {
+	cBlob := byteToChar(blob)
+	C.rocksdb_writebatch_put_log_data(wb.c, cBlob, C.size_t(len(blob)))
+}
+
 // Merge queues a merge of "value" with the existing value of "key".
 func (wb *WriteBatch) Merge(key, value []byte) {
 	cKey := byteToChar(key)


### PR DESCRIPTION
PutLogData API helps to encapsulate metadata in each WAL log item, so that application developers can use that to build replication system with RocksDB and avoid another log component which reduce performance.
-  [Replication-Helpers](https://github.com/facebook/rocksdb/wiki/Replication-Helpers)