### PR TITLE
Adjust go versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 dist: xenial
 language: go
 go:
-  - 1.11
+  - 1.12.x
+  - 1.13.x
   - tip
 
 before_install:


### PR DESCRIPTION
Add 1.12 and 1.13, drop 1.11 as per the convention of go.

fixes #183