### PR TITLE
Updating the README with proposed versioning scheme

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}",
+            "env": {
+            },
+            "args": []
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -4,15 +4,25 @@
 
 ## Install
 
-You'll need to build [RocksDB](https://github.com/facebook/rocksdb) v5.16+ on your machine.
+You'll need to build [RocksDB](https://github.com/facebook/rocksdb) v6.0+  on your machine.
 
 After that, you can install gorocksdb using the following command:
 
     CGO_CFLAGS="-I/path/to/rocksdb/include" \
-    CGO_LDFLAGS="-L/path/to/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd" \
+    CGO_LDFLAGS="-L/path/to/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd -ldl" \
       go get github.com/tecbot/gorocksdb
 
 Please note that this package might upgrade the required RocksDB version at any moment.
 Vendoring is thus highly recommended if you require high stability.
 
 *The [embedded CockroachDB RocksDB](https://github.com/cockroachdb/c-rocksdb) is no longer supported in gorocksdb.*
+
+
+## Previous Versions
+
+The master branch may not be version stable.  If you are looking for a release that is stable for a particular version of rocksdb, use the following compatibility chart:
+
+| gorocksdb version | rocksdb major release compatibility | rocksdb minimum version |
+|:---:|:---:|:---:|
+| v1.0 | 5.X | 5.16 |
+| v2.0 | 6.X | 6.0 |


### PR DESCRIPTION
In order to manage breaking changes in v6  of rocksdb I am proposing create a v1.0 tag for 5.16+ and moving master (and all v2.0+ tags) on to allow breaking changes only found in rocksdb 6