### PR TITLE
Fix defer orders in tests

### DIFF
--- a/cf_test.go
+++ b/cf_test.go
@@ -82,8 +82,8 @@ func TestColumnFamilyBatchPutGet(t *testing.T) {
 	b0.PutCF(cfh[0], givenKey0, givenVal0)
 	ensure.Nil(t, db.Write(wo, b0))
 	actualVal0, err := db.GetCF(ro, cfh[0], givenKey0)
-	defer actualVal0.Free()
 	ensure.Nil(t, err)
+	defer actualVal0.Free()
 	ensure.DeepEqual(t, actualVal0.Data(), givenVal0)
 
 	b1 := NewWriteBatch()
@@ -91,15 +91,17 @@ func TestColumnFamilyBatchPutGet(t *testing.T) {
 	b1.PutCF(cfh[1], givenKey1, givenVal1)
 	ensure.Nil(t, db.Write(wo, b1))
 	actualVal1, err := db.GetCF(ro, cfh[1], givenKey1)
-	defer actualVal1.Free()
 	ensure.Nil(t, err)
+	defer actualVal1.Free()
 	ensure.DeepEqual(t, actualVal1.Data(), givenVal1)
 
 	actualVal, err := db.GetCF(ro, cfh[0], givenKey1)
 	ensure.Nil(t, err)
+	defer actualVal.Free()
 	ensure.DeepEqual(t, actualVal.Size(), 0)
 	actualVal, err = db.GetCF(ro, cfh[1], givenKey0)
 	ensure.Nil(t, err)
+	defer actualVal.Free()
 	ensure.DeepEqual(t, actualVal.Size(), 0)
 }
 
@@ -130,26 +132,29 @@ func TestColumnFamilyPutGetDelete(t *testing.T) {
 
 	ensure.Nil(t, db.PutCF(wo, cfh[0], givenKey0, givenVal0))
 	actualVal0, err := db.GetCF(ro, cfh[0], givenKey0)
-	defer actualVal0.Free()
 	ensure.Nil(t, err)
+	defer actualVal0.Free()
 	ensure.DeepEqual(t, actualVal0.Data(), givenVal0)
 
 	ensure.Nil(t, db.PutCF(wo, cfh[1], givenKey1, givenVal1))
 	actualVal1, err := db.GetCF(ro, cfh[1], givenKey1)
-	defer actualVal1.Free()
 	ensure.Nil(t, err)
+	defer actualVal1.Free()
 	ensure.DeepEqual(t, actualVal1.Data(), givenVal1)
 
 	actualVal, err := db.GetCF(ro, cfh[0], givenKey1)
 	ensure.Nil(t, err)
+	defer actualVal.Free()
 	ensure.DeepEqual(t, actualVal.Size(), 0)
 	actualVal, err = db.GetCF(ro, cfh[1], givenKey0)
 	ensure.Nil(t, err)
+	defer actualVal.Free()
 	ensure.DeepEqual(t, actualVal.Size(), 0)
 
 	ensure.Nil(t, db.DeleteCF(wo, cfh[0], givenKey0))
 	actualVal, err = db.GetCF(ro, cfh[0], givenKey0)
 	ensure.Nil(t, err)
+	defer actualVal.Free()
 	ensure.DeepEqual(t, actualVal.Size(), 0)
 }
 
@@ -194,8 +199,8 @@ func TestColumnFamilyMultiGet(t *testing.T) {
 
 	// column family 0 only has givenKey1
 	values, err := db.MultiGetCF(ro, cfh[0], []byte("noexist"), givenKey1, givenKey2, givenKey3)
-	defer values.Destroy()
 	ensure.Nil(t, err)
+	defer values.Destroy()
 	ensure.DeepEqual(t, len(values), 4)
 
 	ensure.DeepEqual(t, values[0].Data(), []byte(nil))
@@ -205,8 +210,8 @@ func TestColumnFamilyMultiGet(t *testing.T) {
 
 	// column family 1 only has givenKey2 and givenKey3
 	values, err = db.MultiGetCF(ro, cfh[1], []byte("noexist"), givenKey1, givenKey2, givenKey3)
-	defer values.Destroy()
 	ensure.Nil(t, err)
+	defer values.Destroy()
 	ensure.DeepEqual(t, len(values), 4)
 
 	ensure.DeepEqual(t, values[0].Data(), []byte(nil))
@@ -219,8 +224,8 @@ func TestColumnFamilyMultiGet(t *testing.T) {
 		ColumnFamilyHandles{cfh[0], cfh[1], cfh[1]},
 		[][]byte{givenKey1, givenKey2, givenKey3},
 	)
-	defer values.Destroy()
 	ensure.Nil(t, err)
+	defer values.Destroy()
 	ensure.DeepEqual(t, len(values), 3)
 
 	ensure.DeepEqual(t, values[0].Data(), givenVal1)

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -41,16 +41,16 @@ func TestCheckpoint(t *testing.T) {
 	opts := NewDefaultOptions()
 	opts.SetCreateIfMissing(true)
 	dbCheck, err = OpenDb(opts, dir)
-	defer dbCheck.Close()
 	ensure.Nil(t, err)
+	defer dbCheck.Close()
 
 	// test keys
 	var value *Slice
 	ro := NewDefaultReadOptions()
 	for _, k := range givenKeys {
 		value, err = dbCheck.Get(ro, k)
-		defer value.Free()
 		ensure.Nil(t, err)
+		defer value.Free()
 		ensure.DeepEqual(t, value.Data(), givenVal)
 	}
 

--- a/compaction_filter_test.go
+++ b/compaction_filter_test.go
@@ -41,8 +41,8 @@ func TestCompactionFilter(t *testing.T) {
 	// ensure that the value is changed after compaction
 	ro := NewDefaultReadOptions()
 	v1, err := db.Get(ro, changeKey)
-	defer v1.Free()
 	ensure.Nil(t, err)
+	defer v1.Free()
 	ensure.DeepEqual(t, v1.Data(), changeValNew)
 
 	// ensure that the key is deleted after compaction

--- a/db_test.go
+++ b/db_test.go
@@ -30,33 +30,34 @@ func TestDBCRUD(t *testing.T) {
 
 	// retrieve
 	v1, err := db.Get(ro, givenKey)
-	defer v1.Free()
 	ensure.Nil(t, err)
+	defer v1.Free()
 	ensure.DeepEqual(t, v1.Data(), givenVal1)
 
 	// update
 	ensure.Nil(t, db.Put(wo, givenKey, givenVal2))
 	v2, err := db.Get(ro, givenKey)
-	defer v2.Free()
 	ensure.Nil(t, err)
+	defer v2.Free()
 	ensure.DeepEqual(t, v2.Data(), givenVal2)
 
 	// retrieve pinned
 	v3, err := db.GetPinned(ro, givenKey)
-	defer v3.Destroy()
 	ensure.Nil(t, err)
+	defer v3.Destroy()
 	ensure.DeepEqual(t, v3.Data(), givenVal2)
 
 	// delete
 	ensure.Nil(t, db.Delete(wo, givenKey))
 	v4, err := db.Get(ro, givenKey)
 	ensure.Nil(t, err)
+	defer v4.Free()
 	ensure.True(t, v4.Data() == nil)
 
 	// retrieve missing pinned
 	v5, err := db.GetPinned(ro, givenKey)
-	defer v5.Destroy()
 	ensure.Nil(t, err)
+	defer v5.Destroy()
 	ensure.True(t, v5.Data() == nil)
 }
 
@@ -83,8 +84,8 @@ func TestDBCRUDDBPaths(t *testing.T) {
 
 	// retrieve before create
 	noexist, err := db.Get(ro, givenKey)
-	defer noexist.Free()
 	ensure.Nil(t, err)
+	defer noexist.Free()
 	ensure.False(t, noexist.Exists())
 	ensure.DeepEqual(t, noexist.Data(), []byte(nil))
 
@@ -93,32 +94,32 @@ func TestDBCRUDDBPaths(t *testing.T) {
 
 	// retrieve
 	v1, err := db.Get(ro, givenKey)
-	defer v1.Free()
 	ensure.Nil(t, err)
+	defer v1.Free()
 	ensure.True(t, v1.Exists())
 	ensure.DeepEqual(t, v1.Data(), givenVal1)
 
 	// update
 	ensure.Nil(t, db.Put(wo, givenKey, givenVal2))
 	v2, err := db.Get(ro, givenKey)
-	defer v2.Free()
 	ensure.Nil(t, err)
+	defer v2.Free()
 	ensure.True(t, v2.Exists())
 	ensure.DeepEqual(t, v2.Data(), givenVal2)
 
 	// update
 	ensure.Nil(t, db.Put(wo, givenKey, givenVal3))
 	v3, err := db.Get(ro, givenKey)
-	defer v3.Free()
 	ensure.Nil(t, err)
+	defer v3.Free()
 	ensure.True(t, v3.Exists())
 	ensure.DeepEqual(t, v3.Data(), givenVal3)
 
 	// delete
 	ensure.Nil(t, db.Delete(wo, givenKey))
 	v4, err := db.Get(ro, givenKey)
-	defer v4.Free()
 	ensure.Nil(t, err)
+	defer v4.Free()
 	ensure.False(t, v4.Exists())
 	ensure.DeepEqual(t, v4.Data(), []byte(nil))
 }

--- a/filter_policy_test.go
+++ b/filter_policy_test.go
@@ -57,8 +57,8 @@ func TestFilterPolicy(t *testing.T) {
 	// test key may match call
 	ro := NewDefaultReadOptions()
 	v1, err := db.Get(ro, givenKeys[0])
-	defer v1.Free()
 	ensure.Nil(t, err)
+	defer v1.Free()
 	ensure.True(t, keyMayMatchCalled)
 }
 

--- a/merge_operator_test.go
+++ b/merge_operator_test.go
@@ -35,8 +35,8 @@ func TestMergeOperator(t *testing.T) {
 
 	ro := NewDefaultReadOptions()
 	v1, err := db.Get(ro, givenKey)
-	defer v1.Free()
 	ensure.Nil(t, err)
+	defer v1.Free()
 	ensure.DeepEqual(t, v1.Data(), givenMerged)
 }
 
@@ -88,10 +88,9 @@ func TestPartialMergeOperator(t *testing.T) {
 
 	ro := NewDefaultReadOptions()
 	v1, err := db.Get(ro, givenKey)
-	defer v1.Free()
 	ensure.Nil(t, err)
+	defer v1.Free()
 	ensure.DeepEqual(t, v1.Data(), fMergeResult)
-
 }
 
 func TestMergeMultiOperator(t *testing.T) {
@@ -142,10 +141,9 @@ func TestMergeMultiOperator(t *testing.T) {
 
 	ro := NewDefaultReadOptions()
 	v1, err := db.Get(ro, givenKey)
-	defer v1.Free()
 	ensure.Nil(t, err)
+	defer v1.Free()
 	ensure.DeepEqual(t, v1.Data(), fMergeResult)
-
 }
 
 // Mock Objects

--- a/transactiondb_test.go
+++ b/transactiondb_test.go
@@ -33,22 +33,22 @@ func TestTransactionDBCRUD(t *testing.T) {
 
 	// retrieve
 	v1, err := db.Get(ro, givenKey)
-	defer v1.Free()
 	ensure.Nil(t, err)
+	defer v1.Free()
 	ensure.DeepEqual(t, v1.Data(), givenVal1)
 
 	// update
 	ensure.Nil(t, db.Put(wo, givenKey, givenVal2))
 	v2, err := db.Get(ro, givenKey)
-	defer v2.Free()
 	ensure.Nil(t, err)
+	defer v2.Free()
 	ensure.DeepEqual(t, v2.Data(), givenVal2)
 
 	// delete
 	ensure.Nil(t, db.Delete(wo, givenKey))
 	v3, err := db.Get(ro, givenKey)
-	defer v3.Free()
 	ensure.Nil(t, err)
+	defer v3.Free()
 	ensure.True(t, v3.Data() == nil)
 
 	// transaction
@@ -57,14 +57,14 @@ func TestTransactionDBCRUD(t *testing.T) {
 	// create
 	ensure.Nil(t, txn.Put(givenTxnKey, givenTxnVal1))
 	v4, err := txn.Get(ro, givenTxnKey)
-	defer v4.Free()
 	ensure.Nil(t, err)
+	defer v4.Free()
 	ensure.DeepEqual(t, v4.Data(), givenTxnVal1)
 
 	ensure.Nil(t, txn.Commit())
 	v5, err := db.Get(ro, givenTxnKey)
-	defer v5.Free()
 	ensure.Nil(t, err)
+	defer v5.Free()
 	ensure.DeepEqual(t, v5.Data(), givenTxnVal1)
 
 	// transaction
@@ -76,8 +76,8 @@ func TestTransactionDBCRUD(t *testing.T) {
 	ensure.Nil(t, txn2.Rollback())
 
 	v6, err := txn2.Get(ro, givenTxnKey2)
-	defer v6.Free()
 	ensure.Nil(t, err)
+	defer v6.Free()
 	ensure.True(t, v6.Data() == nil)
 	// transaction
 	txn3 := db.TransactionBegin(wo, to, nil)
@@ -87,8 +87,8 @@ func TestTransactionDBCRUD(t *testing.T) {
 	ensure.Nil(t, txn3.Commit())
 
 	v7, err := db.Get(ro, givenTxnKey)
-	defer v7.Free()
 	ensure.Nil(t, err)
+	defer v7.Free()
 	ensure.True(t, v7.Data() == nil)
 
 }
@@ -113,8 +113,8 @@ func TestTransactionDBGetForUpdate(t *testing.T) {
 	defer txn.Destroy()
 
 	v, err := txn.GetForUpdate(ro, givenKey)
-	defer v.Free()
 	ensure.Nil(t, err)
+	defer v.Free()
 
 	// expect lock timeout error to be thrown
 	if err := db.Put(wo, givenKey, givenVal); err == nil {

--- a/write_batch_test.go
+++ b/write_batch_test.go
@@ -31,13 +31,13 @@ func TestWriteBatch(t *testing.T) {
 	// check changes
 	ro := NewDefaultReadOptions()
 	v1, err := db.Get(ro, givenKey1)
-	defer v1.Free()
 	ensure.Nil(t, err)
+	defer v1.Free()
 	ensure.DeepEqual(t, v1.Data(), givenVal1)
 
 	v2, err := db.Get(ro, givenKey2)
-	defer v2.Free()
 	ensure.Nil(t, err)
+	defer v2.Free()
 	ensure.True(t, v2.Data() == nil)
 
 	// DeleteRange test
@@ -48,8 +48,8 @@ func TestWriteBatch(t *testing.T) {
 	ensure.Nil(t, db.Write(wo, wb))
 
 	v1, err = db.Get(ro, givenKey1)
-	defer v1.Free()
 	ensure.Nil(t, err)
+	defer v1.Free()
 	ensure.True(t, v1.Data() == nil)
 }
 


### PR DESCRIPTION
If error is nil, defer should be called otherwise, it will panic.